### PR TITLE
Feat 6396 Postmark Messaging Adapter

### DIFF
--- a/src/Utopia/Messaging/Adapters/Email/Postmark.php
+++ b/src/Utopia/Messaging/Adapters/Email/Postmark.php
@@ -1,0 +1,66 @@
+<?php
+
+
+namespace Utopia\Messaging\Adapters\Email;
+
+use Utopia\Messaging\Adapters\Email as EmailAdapter;
+use Utopia\Messaging\Messages\Email;
+
+class Postmark extends EmailAdapter
+{
+    /**
+     * @param  string  $apiKey Your Postmark API key to authenticate with the API.
+     */
+    public function __construct(
+        private string $apiKey
+    ) {
+    }
+
+    /**
+     * Get adapter name.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Postmark';
+    }
+
+    /**
+     * Get adapter description.
+     *
+     * @return int
+     */
+    public function getMaxMessagesPerRequest(): int
+    {
+        return 50;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Exception
+     */
+    protected function process(Email $message): string
+    {
+        $bodyKey = $message->isHtml() ? 'HtmlBody' : 'TextBody';
+
+        $response = $this->request(
+            method: 'POST',
+            url: "https://api.postmarkapp.com/email",
+            headers: [
+                'Accept: application/json',
+                'Content-Type: application/json',
+                'X-Postmark-Server-Token: '.$this->apiKey,
+            ],
+            body: \json_encode([
+                'To' => \implode(',', $message->getTo()),
+                'From' => $message->getFrom(),
+                'Subject' => $message->getSubject(),
+                $bodyKey => $message->getContent(),
+            ]),
+        );
+
+        return $response;
+    }
+}

--- a/tests/e2e/Email/PostmarkTest.php
+++ b/tests/e2e/Email/PostmarkTest.php
@@ -12,6 +12,8 @@ class PostmarkTest extends Base
      */
     public function testSendPlainTextEmail()
     {
+        $this->markTestSkipped('Postmark credentials not set.');
+
         $key = getenv('POSTMARK_API_KEY');
         $sender = new Postmark($key);
 

--- a/tests/e2e/Email/PostmarkTest.php
+++ b/tests/e2e/Email/PostmarkTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\E2E;
+
+use Utopia\Messaging\Adapters\Email\Postmark;
+use Utopia\Messaging\Messages\Email;
+
+class PostmarkTest extends Base
+{
+    /**
+     * @throws \Exception
+     */
+    public function testSendPlainTextEmail()
+    {
+        $key = getenv('POSTMARK_API_KEY');
+        $sender = new Postmark($key);
+
+        $to = getenv('TEST_EMAIL');
+        $subject = 'Test Subject';
+        $content = 'Test Content';
+        $from = getenv('TEST_FROM_EMAIL');
+
+        $message = new Email(
+            to: [$to],
+            from: $from,
+            subject: $subject,
+            content: $content,
+        );
+
+        $result = (array) \json_decode($sender->send($message));
+
+        $this->assertEquals($to, $result['To']);
+        $this->assertEquals("OK", $result['Message']);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Please help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR implements a simple Postmark Email adapter.

## Test Plan

Included test suite has been marked as skipped given no API key is available in CI. But the test plan is described as follows:

While Postmark provides an API key for testing the key only verifies the data is correct. So I opted to include a new E2E test for Postmark. To run it, a Postmark account with a domain attached and two email accounts are required.

1) Create a new account on https://postmarkapp.com/
2) Follow the steps outlined by Postmark for a Sender Signature.
3) Have two email addresses available on your attached domain.
4) Grab your API key from `Servers > My First Server > API tokens`
5) Open `utopia-php/messaging` root directory in a terminal.
6) Run `composer install` to install PHPUnit and related packages.

Now the E2E can be executed with the provided API key as the environment variable `POSTMARK_API_KEY`. The `TEST_EMAIL` and `TEST_FROM_EMAIL` **must** be open, real email addresses and are **required** to be of the same domain. Namely, the same domain as your Sender Signature. 

```bash
POSTMARK_API_KEY= TEST_EMAIL= TEST_FROM_EMAIL= ./vendor/bin/phpunit tests/e2e/Email/PostmarkTest.php
```

Included below is a video showing the E2E test running:

https://github.com/utopia-php/messaging/assets/2221746/f28ec0a3-4abc-4851-aefa-8d79e2a221d7

## Related PRs and Issues

Closes: https://github.com/appwrite/appwrite/issues/6396

### Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md)?

Yes. 👍