### PR TITLE
Added MailSlurp adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ $messaging->send($message);
 - [ ] [Postmark](https://postmarkapp.com/)
 - [ ] [SparkPost](https://www.sparkpost.com/)
 - [ ] [SendinBlue](https://www.sendinblue.com/)
-- [ ] [MailSlurp](https://www.mailslurp.com/)
+- [x] [MailSlurp](https://www.mailslurp.com/)
 - [ ] [ElasticEmail](https://elasticemail.com/)
 - [ ] [SES](https://aws.amazon.com/ses/)
 

--- a/src/Utopia/Messaging/Adapters/Email/MailSlurp.php
+++ b/src/Utopia/Messaging/Adapters/Email/MailSlurp.php
@@ -34,9 +34,7 @@ class MailSlurp extends EmailAdapter
      */
     public function getMaxMessagesPerRequest(): int
     {
-		// TODO: Find out the actual limit.
-		// The docs say "limit varies from plan to plan", but I sent them an email asking for clarification and
-		// will update this when I get a response.
+		// TODO: Find out the actual limit. The docs say "limit varies from plan to plan" without exact numbers.
         return 1000;
     }
 

--- a/src/Utopia/Messaging/Adapters/Email/MailSlurp.php
+++ b/src/Utopia/Messaging/Adapters/Email/MailSlurp.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Utopia\Messaging\Adapters\Email;
+
+use Utopia\Messaging\Adapters\Email as EmailAdapter;
+use Utopia\Messaging\Messages\Email;
+
+class MailSlurp extends EmailAdapter
+{
+    /**
+     * @param  string $apiKey Your MailSlurp API key to authenticate with the API.
+     * @param  ?string $inboxId Your MailSlurp inbox ID to send emails from. If left empty, a random inbox will be used.
+     */
+    public function __construct(
+        private string $apiKey,
+        private ?string $inboxId = null,
+    ) {
+    }
+
+    /**
+     * Get adapter name.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'MailSlurp';
+    }
+
+    /**
+     * Get adapter description.
+     *
+     * @return int
+     */
+    public function getMaxMessagesPerRequest(): int
+    {
+		// TODO: Find out the actual limit.
+		// The docs say "limit varies from plan to plan", but I sent them an email asking for clarification and
+		// will update this when I get a response.
+        return 1000;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Exception
+     */
+    protected function process(Email $message): string
+    {
+		$url = "https://api.mailslurp.com/emails";
+		if ($this->inboxId !== null) {
+			$url .= '?inboxId='.$this->inboxId;
+		}
+		return $this->request(
+			method: 'POST',
+			url: $url,
+			headers: [
+				'x-api-key: '.$this->apiKey,
+				'Content-Type: application/json',
+			],
+			body: \json_encode([
+				'to' => $message->getTo(),
+				'from' => $message->getFrom(),
+				'subject' => $message->getSubject(),
+				'text' => $message->getContent(),
+				'html' => $message->isHtml(),
+			]),
+		);
+    }
+}

--- a/tests/e2e/Email/MailSlurpTest.php
+++ b/tests/e2e/Email/MailSlurpTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\E2E;
+
+use Utopia\Messaging\Adapters\Email\MailSlurp;
+use Utopia\Messaging\Messages\Email;
+
+class MailSlurpTest extends Base
+{
+    /**
+     * @throws \Exception
+     */
+    public function testSendEmail()
+    {
+        $key = getenv('MAILSLURP_API_KEY');
+		$inboxId = getenv('MAILSLURP_INBOX_ID');
+        $sender = new MailSlurp($key, empty($inboxId) ? null : $inboxId);
+
+        $to = getenv('TEST_EMAIL');
+        $subject = 'Test Subject';
+        $content = 'Test Content';
+        $from = getenv('TEST_FROM_EMAIL');
+
+        $message = new Email(
+            to: [$to],
+			subject: $subject,
+			content: $content,
+			from: $from,
+        );
+
+        $response = $sender->send($message);
+        $this->assertEquals($response, '');
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Adds the MailSlurp email adapter. The exact limit for getMaxMessagerPerRequest() is not documented, but I emailed the MailSlurp support team for more info and left a TODO there for now.

## Test Plan

I've created a free MailSlurp personal plan, added a MailSlurpTest.php file and tested it successfully.

## Related PRs and Issues
https://github.com/appwrite/appwrite/issues/6390