### PR TITLE
Add Adapters and tests for Mailtrap.

### DIFF
--- a/src/Utopia/Messaging/Adapters/Email/Mailtrap.php
+++ b/src/Utopia/Messaging/Adapters/Email/Mailtrap.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Utopia\Messaging\Adapters\Email;
+
+use Utopia\Messaging\Adapters\Email as EmailAdapter;
+use Utopia\Messaging\Messages\Email;
+
+class Mailtrap extends EmailAdapter
+{
+    /**
+     * @param  string  $apiKey Your Mailtrap API key to authenticate with the API.
+     * @return void
+     */
+    public function __construct(private string $apiKey)
+    {
+    }
+
+    /**
+     * Get adapter name.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Mailtrap';
+    }
+
+    /**
+     * Get max messages per request.
+     *
+     * @return int
+     */
+    public function getMaxMessagesPerRequest(): int
+    {
+        return 1000;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param  Email  $message
+     * @return string
+     *
+     * @throws Exception
+     */
+    protected function process(Email $message): string
+    {
+        $bodyKey = $message->isHtml() ? 'html' : 'text';
+
+        $response= $this->request(
+            method: 'POST',
+            url: 'https://send.api.mailtrap.io/api/send',
+            headers: [
+                'Accept: application/json',
+                'Api-Token: '.$this->apiKey,
+                'Content-Type: application/json',
+            ],
+            body: \json_encode([
+                'to' => \array_map(
+                    fn ($to) => ['email' => $to],
+                    $message->getTo()
+                ),
+                "subject" =>$message->getSubject(),
+                $bodyKey => $message->getContent(),
+                'from' => [
+                    'email' => $message->getFrom(),
+                ],
+            ]),
+        );
+        return $response;
+    }
+}
+

--- a/tests/e2e/Email/MailtrapTest.php
+++ b/tests/e2e/Email/MailtrapTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\E2E;
+
+use Utopia\Messaging\Adapters\Email\Mailtrap;
+use Utopia\Messaging\Messages\Email;
+
+class MailtrapTest extends Base
+{
+    /**
+     * @throws \Exception
+     */
+    public function testSendPlainTextEmail()
+    {
+        $this->markTestSkipped('Mailtrap credentials not set.');
+
+        $key = getenv('MAILTAP_API_KEY');
+        $sender = new Mailtrap($key);
+
+        $to = getenv('TEST_EMAIL');
+        $subject = 'Test Subject';
+        $content = 'Test Content';
+        $from = getenv('TEST_FROM_EMAIL');
+
+        $message = new Email(
+            to: [$to],
+            from: $from,
+            subject: $subject,
+            content: $content,
+        );
+
+        $response = $sender->send($message);
+        
+        $this->assertArrayHasKey('messageId', json_decode($response, true));
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR implements Mailtrap Email adapter.


## Test Plan for Running the Mailtrap E2E Test
By default, the Mailtrap E2E test is marked as skipped. 

To execute the Mailtrap E2E test suite, you will need a Mailtrap account with a domain attached and two valid email addresses associated with that domain. Please follow these steps:

1. *Create a Mailtrap Account:*
   - Create a new account on [Mailtrap](https://mailtrap.io/).

2. *Set Up a Sender Signature:*
   - Set up a Sender Signature within your Mailtrap account, following the steps provided by Mailtrap.

3. *Prepare Email Addresses:*
   - Ensure you have two email addresses available within your Mailtrap account, both associated with the same domain as your Sender Signature.

4. *Obtain Mailtrap API Key:*
   - Obtain your Mailtrap API key from the Mailtrap dashboard. You can usually find it in your account settings.

5. *Install PHPUnit and Dependencies:*
   - Open a terminal and navigate to the root directory of your 'utopia-php/messaging' project.
   - Run the following command to install PHPUnit and related packages using Composer:
     ```sh
     composer install
     ```
     

6. *Run E2E Tests:*
   - With the required setup complete, you can now execute the E2E tests, providing the necessary environment variables. Replace `YOUR_MAILTRAP_API_KEY`, `YOUR_TEST_EMAIL`, and `YOUR_TEST_FROM_EMAIL` with your actual Mailtrap API key, test email address, and from email address, respectively. Make sure that `YOUR_TEST_EMAIL` and `YOUR_TEST_FROM_EMAIL` belong to the same domain as your Sender Signature.
   
     ```sh
     MAILTRAP_API_KEY=YOUR_MAILTRAP_API_KEY   TEST_EMAIL=YOUR_TEST_EMAIL TEST_FROM_EMAIL=YOUR_TEST_FROM_EMAIL ./vendor/bin/phpunit tests/e2e/Email/MailtrapTest.php
      ```
     

## Related PRs and Issues

Closes: appwrite/appwrite#6391

### Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md)?

YES
