### PR TITLE
Add brevo adapter and test suite for the same.

### DIFF
--- a/src/Utopia/Messaging/Adapters/Email/Brevo.php
+++ b/src/Utopia/Messaging/Adapters/Email/Brevo.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Utopia\Messaging\Adapters\Email;
+
+use Utopia\Messaging\Messages\Email;
+use Utopia\Messaging\Adapters\Email as EmailAdapter;
+
+class Brevo extends EmailAdapter
+{
+    public function __construct(private string $apiKey) 
+    {
+    }
+
+    public function getName(): string
+    {
+        return 'Brevo';
+    }
+
+    public function getMaxMessagesPerRequest(): int
+    {
+        return 1000;
+    }
+
+    protected function process(Email $message): string
+    {
+        $bodyKey = $message->isHtml() ? 'htmlContent' : 'textContent';
+        return $this->request(
+            method: 'POST',
+            url: 'https://api.brevo.com/v3/smtp/email',
+            headers: [
+                'accept: application/json',
+                'Content-Type: application/json',
+                'api-key: '.$this->apiKey,
+            ],
+            body: \json_encode([
+                "sender" => [
+                    "email" => $message->getFrom()
+                ],
+                "to" => \array_map(
+                    fn ($to) => ['email' => $to],
+                    $message->getTo()
+                ),
+                "subject" => $message->getSubject(),
+                $bodyKey => $message->getContent(),
+            ])
+        );
+    }
+}

--- a/tests/e2e/Email/BrevoTest.php
+++ b/tests/e2e/Email/BrevoTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\E2E;
+
+use Utopia\Messaging\Adapters\Email\Brevo;
+use Utopia\Messaging\Messages\Email;
+
+class BrevoTest extends Base
+{
+    /**
+     * @throws \Exception
+     */
+    public function testSendPlainTextEmail()
+    {
+        // $this->markTestSkipped('Brevo credentials not set.');
+
+        $key = getenv('BREVO_API_KEY');
+        $sender = new Brevo($key);
+
+        $to = getenv('TEST_EMAIL');
+        $subject = 'Test Subject';
+        $content = 'Test Content';
+        $from = getenv('TEST_FROM_EMAIL');
+
+        $message = new Email(
+            to: [$to],
+            from: $from,
+            subject: $subject,
+            content: $content,
+        );
+
+        $response = $sender->send($message);
+        $this->assertArrayHasKey('messageId', json_decode($response, true));
+
+
+    
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR implements brevo email adapter.

## Test Plan

To execute the Brevo E2E test suite, you will need a Brevo account with certain requirements. Please follow these steps:

1. **Create a Brevo Account:**
   - Create a new account on [Brevo](https://onboarding.brevo.com/account/register).

2. **Set Up Sender Information:**
   - Follow the steps outlined by Brevo for setting up sender information.

3. **Prepare Email Addresses:**
   - Ensure you have two valid email addresses available, one for sending and one for receiving emails. These email addresses should be associated with the domain you've set up in your Sender Signature.

4. **Obtain Brevo API Key:**
   - Grab your API key from Brevo. You can usually find it in your account settings or by visiting the API tokens section.

5. **Install Required PHP Extensions: (For unix-based distributions)**
   - Ensure that your PHP environment is properly configured by installing the necessary extensions. Run the following commands to install the required PHP extensions:
     ```sh
     sudo apt-get install php-mbstring
     sudo apt-get install php-curl
     sudo apt install php-xml
     sudo php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
     ```

6. **Install PHPUnit and Dependencies:**
   - Open a terminal and navigate to the root directory of your 'utopia-php/messaging' project.
   - Run the following command to install PHPUnit and related packages using Composer:
     ```sh
     composer install
     ```

7. **Run E2E Tests:**
   - With the required setup complete, you can now execute the E2E tests, providing the necessary environment variables. Replace `YOUR_BREVO_API_KEY`, `YOUR_TEST_EMAIL`, and `YOUR_TEST_FROM_EMAIL` with your actual Brevo API key, test email address, and from email address, respectively. Ensure that `YOUR_TEST_EMAIL` and `YOUR_TEST_FROM_EMAIL` belong to the same domain as your Sender Signature:
     ```sh
     BREVO_API_KEY=YOUR_BREVO_API_KEY TEST_EMAIL=YOUR_TEST_EMAIL TEST_FROM_EMAIL=YOUR_TEST_FROM_EMAIL ./vendor/bin/phpunit tests/e2e/Email/BrevoTest.php
     ```

## Video Demonstration

To get a visual walkthrough of running the Brevo E2E test, watch the video provided below:

https://github.com/utopia-php/messaging/assets/119918405/afcd192e-3e75-48d9-8dc4-d4dc648a0eb8




## Related PRs and Issues
closes: https://github.com/appwrite/appwrite/issues/6384

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md)?

Yes
