### PR TITLE
Added Pusher Messaging Adapter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         fetch-depth: 2
     - run: git checkout HEAD^2
-    - name: Run Tests 
+    - name: Run Tests
       env:
         MAILGUN_API_KEY: ${{ secrets.MAILGUN_API_KEY }}
         MAILGUN_DOMAIN: ${{ secrets.MAILGUN_DOMAIN }}
@@ -40,6 +40,9 @@ jobs:
         VONAGE_API_SECRET: ${{ secrets.VONAGE_API_SECRET }}
         VONAGE_TO: ${{ secrets.VONAGE_TO }}
         VONAGE_FROM: ${{ secrets.VONAGE_FROM }}
+        PUSHER_INSTANCE_ID: ${{ secrets.PUSHER_INSTANCE_ID }}
+        PUSHER_SECRET_KEY: ${{ secrets.PUSHER_SECRET_KEY }}
+        PUSHER_TO: ${{ secrets.PUSHER_TO }}
       run: |
         docker compose up -d --build
         sleep 5

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ $messaging->send($message);
 - [x] [FCM](https://firebase.google.com/docs/cloud-messaging)
 - [ ] [APNS](https://developer.apple.com/documentation/usernotifications)
 - [ ] [OneSignal](https://onesignal.com/)
-- [ ] [Pusher](https://pusher.com/)
+- [x] [Pusher](https://pusher.com/)
 - [ ] [WebPush](https://developer.mozilla.org/en-US/docs/Web/API/Push_API)
 - [ ] [UrbanAirship](https://www.urbanairship.com/)
 - [ ] [Pushwoosh](https://www.pushwoosh.com/)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,13 +29,16 @@ services:
     - VONAGE_API_SECRET
     - VONAGE_TO
     - VONAGE_FROM
+    - PUSHER_INSTANCE_ID
+    - PUSHER_SECRET_KEY
+    - PUSHER_TO
     build:
       context: .
     volumes:
       - ./src:/usr/local/src/src
       - ./tests:/usr/local/src/tests
       - ./phpunit.xml:/usr/local/src/phpunit.xml
-      
+
   maildev:
     image: appwrite/mailcatcher:1.0.0
     ports:

--- a/src/Utopia/Messaging/Adapters/Push/Pusher.php
+++ b/src/Utopia/Messaging/Adapters/Push/Pusher.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Utopia\Messaging\Adapters\Push;
+
+use Utopia\Messaging\Adapters\Push as PushAdapter;
+use Utopia\Messaging\Messages\Push;
+
+class Pusher extends PushAdapter
+{
+    /**
+     * @param  string  $instanceId The unique identifier for Pusher Beams instance.
+     * @param  string  $secretKey The secret key to access Pusher Beams instance.
+     */
+    public function __construct(
+        private string $instanceId,
+        private string $secretKey,
+    ) {
+    }
+
+    /**
+     * Get adapter name.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Pusher';
+    }
+
+    /**
+     * Get max messages per request.
+     *
+     * @return int
+     */
+    public function getMaxMessagesPerRequest(): int
+    {
+        return 1000;
+    }
+
+    private function removeNullFields(array $object): array
+    {
+        $output = [];
+        foreach ($object as $key => $val) {
+            if (is_array($val) && array_keys($val) !== range(0, count($val) - 1)) {
+                $output[$key] = $this->removeNullFields($val);
+            } elseif (! is_null($val)) {
+                $output[$key] = $val;
+            }
+        }
+
+        return $output;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Exception
+     */
+    protected function process(Push $message): string
+    {
+        return $this->request(
+            method: 'POST',
+            url: "https://{$this->instanceId}.pushnotifications.pusher.com/publish_api/v1/instances/{$this->instanceId}/publishes/users",
+            headers: [
+                'Content-Type: application/json',
+                "Authorization: Bearer {$this->secretKey}",
+            ],
+            body: \json_encode($this->removeNullFields([
+                'users' => $message->getTo(),
+                'apns' => [
+                    'aps' => [
+                        'alert' => [
+                            'title' => $message->getTitle(),
+                            'body' => $message->getBody(),
+                        ],
+                        'badge' => $message->getBadge(),
+                        'sound' => $message->getSound(),
+                        'data' => $message->getData(),
+                    ],
+                ],
+                'fcm' => [
+                    'notification' => [
+                        'title' => $message->getTitle(),
+                        'body' => $message->getBody(),
+                        'click_action' => $message->getAction(),
+                        'icon' => $message->getIcon(),
+                        'color' => $message->getColor(),
+                        'sound' => $message->getSound(),
+                        'tag' => $message->getTag(),
+                    ],
+                    'data' => $message->getData(),
+                ],
+                'web' => [
+                    'notification' => [
+                        'title' => $message->getTitle(),
+                        'body' => $message->getBody(),
+                        'icon' => $message->getIcon(),
+                    ],
+                    'data' => $message->getData(),
+                ],
+            ]))
+        );
+    }
+}

--- a/tests/e2e/Push/PusherTest.php
+++ b/tests/e2e/Push/PusherTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\E2E;
+
+use Utopia\Messaging\Adapters\Push\Pusher as PusherAdapter;
+use Utopia\Messaging\Messages\Push;
+
+class PusherTest extends Base
+{
+    public function testSend(): void
+    {
+        $instanceId = getenv('PUSHER_INSTANCE_ID');
+        $secretKey = getenv('PUSHER_SECRET_KEY');
+
+        $adapter = new PusherAdapter($instanceId, $secretKey);
+
+        $to = getenv('PUSHER_TO');
+
+        $message = new Push(
+            to: [$to],
+            title: 'TestTitle',
+            body: 'TestBody',
+            data: [
+                'some' => 'metadata',
+            ],
+            action: null,
+            sound: 'default',
+            icon: null,
+            color: null,
+            tag: null,
+            badge: '1'
+        );
+
+        $response = \json_decode($adapter->send($message));
+
+        $this->assertNotEmpty($response);
+        $this->assertIsString($response->publishId);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds a new Push Adapter for sending push notification via Pusher.

## Test Plan

- Create a free account on [Pusher](https://dashboard.pusher.com/accounts/sign_up)
- Add the following environment variables
  - PUSHER_INSTANCE_ID: <Pusher Beams instance id, can be found in the dashboard under Keys > Credentials>
  - PUSHER_SECRET_KEY: <Pusher Beams secret key, can be found in the dashboard under Keys > Credentials>
  - PUSHER_TO: <userId e.g. 'test-user-id'>
- Run test against tests/e2e/Push/PusherTest.php

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/6398

### Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md)?

Yes
