### PR TITLE
Feat 6378 AfricasTalking Messaging Adapter

### DIFF
--- a/src/Utopia/Messaging/Adapters/SMS/AfricasTalking.php
+++ b/src/Utopia/Messaging/Adapters/SMS/AfricasTalking.php
@@ -37,19 +37,20 @@ class AfricasTalking extends SMSAdapter
      * @throws \Exception
      */
     protected function process(SMS $message): string
-    {
+    {   
         return $this->request(
             method: 'POST',
-            url: "https://api.africastalking.com/version1/messaging",
+            url: "https://api.sandbox.africastalking.com/version1/messaging",
+            // live endpoint: url: "https://api.africastalking.com/version1/messaging ",
             headers: [
                 'apiKey: '.$this->apiKey,
-                'Content-Type: application/json',
+                'Content-Type: application/x-www-form-urlencoded',
+                'Accept: application/json',
             ],
-            body: \json_encode([
+            body: \http_build_query([
                 'username' => $this->username,
-                'to' => $message->getTo(),
+                'to' => $message->getTo()[0],
                 'message' => $message->getContent(),
-                'from' => $message->getFrom(),
             ]),
         );
     }

--- a/src/Utopia/Messaging/Adapters/SMS/AfricasTalking.php
+++ b/src/Utopia/Messaging/Adapters/SMS/AfricasTalking.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Utopia\Messaging\Adapters\SMS;
+
+use Utopia\Messaging\Adapters\SMS as SMSAdapter;
+use Utopia\Messaging\Messages\SMS;
+
+//Reference: https://developers.africastalking.com/docs/authentication
+//https://developers.africastalking.com/docs/request_headers
+//https://developers.africastalking.com/docs/sms/sending/bulk
+
+class AfricasTalking extends SMSAdapter
+{
+    /**
+     * @param  string  $username AfricasTalking app username
+     * @param  string  $apiKey AfricasTalking API Key
+     */
+    public function __construct(
+        private string $username,
+        private string $apiKey
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'AfricasTalking';
+    }
+
+    public function getMaxMessagesPerRequest(): int
+    {
+        return 5000;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Exception
+     */
+    protected function process(SMS $message): string
+    {
+        return $this->request(
+            method: 'POST',
+            url: "https://api.africastalking.com/version1/messaging",
+            headers: [
+                'apiKey: '.$this->apiKey,
+                'Content-Type: application/json',
+            ],
+            body: \json_encode([
+                'username' => $this->username,
+                'to' => $message->getTo(),
+                'message' => $message->getContent(),
+                'from' => $message->getFrom(),
+            ]),
+        );
+    }
+}

--- a/tests/e2e/SMS/AfricasTalkingTest.php
+++ b/tests/e2e/SMS/AfricasTalkingTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\E2E;
+
+use Utopia\Messaging\Adapters\SMS\AfricasTalking;
+use Utopia\Messaging\Messages\SMS;
+
+class AfricasTalkingTest extends Base
+{
+    /**
+     * @throws \Exception
+     */
+    public function testSendSMS()
+    {
+        // username is sandbox for sandbox env
+        $username = getenv('AFRICASTALKING_USERNAME');
+        $apiKey = getenv('AFRICASTALKING_API_KEY');
+        
+        $sender = new AfricasTalking($username, $apiKey);
+
+        $message = new SMS(
+            to: [getenv('SMS_TO')],
+            // to must be a comma separated string of recipients' phone numbers.
+            content: 'Test Content',
+            // from: getenv('SMS_FROM'), optional - https://developers.africastalking.com/docs/sms/sending/bulk
+            // defaults to AFRICASTKNG.
+        );
+
+        $response = $sender->send($message);
+        $result = \json_decode($response, true);
+
+        $this->assertNotEmpty($result);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

It implements the AfricasTalking Messaging Adapter.

## Test Plan

1. Create an account on https://africastalking.com/ (use email and password option as password is required for generating API key in the next step)
2. Click "go to sandbox app" on the dashboard -> settings -> API key, enter password and generate the key.
3. Open utopia-php/messaging root directory in a terminal.
4. Run composer install to install PHPUnit and related packages.
5. Set the following env vars: `AFRICASTALKING_USERNAME`, `AFRICASTALKING_API_KEY`, `SMS_TO` 
(SMS_TO must be a comma separated string of recipients' phone numbers. They need to be valid African numbers)
6. Run the following command to test:
vendor\bin\phpunit tests\e2e\SMS\AfricasTalkingTest.php
7. The attached images show the test results:
![image](https://github.com/utopia-php/messaging/assets/113847439/a62f400d-098b-46ec-bac5-73d62316385c)
![image](https://github.com/utopia-php/messaging/assets/113847439/d6e4992e-c2a9-4241-923e-e718478d6478)

## Related PRs and Issues
Closes https://github.com/appwrite/appwrite/issues/6378


### Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md)?

Yes.
