### PR TITLE
feat: add messagbird messaging adapter

### DIFF
--- a/src/Utopia/Messaging/Adapters/SMS/MessageBird.php
+++ b/src/Utopia/Messaging/Adapters/SMS/MessageBird.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Utopia\Messaging\Adapters\SMS;
+
+use Utopia\Messaging\Adapters\SMS as SMSAdapter;
+use Utopia\Messaging\Messages\SMS;
+
+class MessageBird extends SMSAdapter {
+  /**
+   * @param  string  $authToken MessageBird Auth Token
+   */
+  public function __construct(
+    private string $authToken,
+  ) {
+  }
+
+  public function getName(): string {
+    return 'MessageBird';
+  }
+
+  public function getMaxMessagesPerRequest(): int {
+    return 50;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @throws \Exception
+   */
+  protected function process(SMS $message): string {
+    $to = \array_map(
+      fn ($to) => \ltrim($to, '+'),
+      $message->getTo()
+    );
+
+    return $this->request(
+      method: 'POST',
+      url: "https://rest.messagebird.com/messages",
+      headers: [
+        'Authorization: AccessKey ' . $this->authToken,
+        'Content-Type: application/json',
+      ],
+      body: \json_encode([
+        "recipients" => $to,
+        "originator" => $message->getFrom(),
+        "body" => $message->getContent(),
+
+      ])
+    );
+  }
+}

--- a/tests/e2e/SMS/MessageBirdTest.php
+++ b/tests/e2e/SMS/MessageBirdTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Test\E2E;
+
+use Tests\E2E\Base;
+use Utopia\Messaging\Messages\SMS;
+use Utopia\Messaging\Adapters\SMS\MessageBird;
+
+
+class MessageBirdTest extends Base {
+  /**
+   * @throws \Exception
+   */
+  public function testSendSMS() {
+    $apiKey = getenv('MESSAGEBIRD_API_KEY');
+
+
+    $sender = new MessageBird($apiKey);
+
+    $message = new SMS(
+      to: [getenv('MESSAGEBIRD_TO')],
+      content: 'Test Content',
+      from: getenv('MESSAGEBIRD_FROM')
+    );
+
+    $response = $sender->send($message);
+    print_r($response);
+    $result = \json_decode($response, true);
+
+    $this->assertArrayHasKey('body', $result);
+    $this->assertEquals('Test Content', $result['body']);
+    $this->assertEquals(1, count($result['recipients']['items']));
+  }
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR adds messagebird messging adapter with tests

## Test Plan

1. create your [messagebird](https://dashboard.messagebird.com/en/sign-up) account
2. get your API Key from the messagebird dashboard
3. set up your Virtual mobile number and/or originator from the messagebird dashboard
4. add environment variables and run E2E test.
```bash
MESSAGEBIRD_API_KEY="TEST_API_KEY" MESSAGEBIRD_TO="+2347034542344" MESSAGEBIRD_FROM="2347034542344" ./vendor/bin/phpunit tests/e2e/SMS/MessageBirdTest.php
```

## Related PRs and Issues
Closes appwrite/appwrite#6392
Closes #38 


### Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md)?

Yes