### PR TITLE
Added Pushy Messaging Adapter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,8 @@ jobs:
         VONAGE_API_SECRET: ${{ secrets.VONAGE_API_SECRET }}
         VONAGE_TO: ${{ secrets.VONAGE_TO }}
         VONAGE_FROM: ${{ secrets.VONAGE_FROM }}
+        PUSHY_SECRET_KEY: ${{ secrets.PUSHY_SECRET_KEY }}
+        PUSHY_SERVER_TO: ${{ secrets.PUSHY_SERVER_TO }}
       run: |
         docker compose up -d --build
         sleep 5

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ $messaging->send($message);
 - [ ] [UrbanAirship](https://www.urbanairship.com/)
 - [ ] [Pushwoosh](https://www.pushwoosh.com/)
 - [ ] [PushBullet](https://www.pushbullet.com/)
-- [ ] [Pushy](https://pushy.me/)
+- [x] [Pushy](https://pushy.me/)
 
 ## System Requirements
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
     - VONAGE_API_SECRET
     - VONAGE_TO
     - VONAGE_FROM
+    - PUSHY_SECRET_KEY
+    - PUSHY_SERVER_TO
     build:
       context: .
     volumes:

--- a/src/Utopia/Messaging/Adapters/Push/Pushy.php
+++ b/src/Utopia/Messaging/Adapters/Push/Pushy.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Utopia\Messaging\Adapters\Push;
+
+use Utopia\Messaging\Adapters\Push as PushAdapter;
+use Utopia\Messaging\Messages\Push;
+
+class Pushy extends PushAdapter
+{
+    /**
+     * @param  string  $secretKey The secret API  key that pushy provides.
+     */
+    public function __construct(
+        private string $secretKey,
+    ) {
+    }
+
+    /**
+     * Get adapter name.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Pushy';
+    }
+
+    /**
+     * Get max messages per request.
+     *
+     * @return int
+     */
+    public function getMaxMessagesPerRequest(): int
+    {
+        return 1000;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Exception
+     */
+    public function process(Push $message): string
+    {
+
+        return $this->request(
+            method: 'POST',
+            url: "https://api.pushy.me/push?api_key={$this->secretKey}",
+            headers: [
+                'Content-Type: application/json',
+            ],
+            body: \json_encode([
+                'to' => $message->getTo(),
+                'data' => $message->getData(),
+                'notifications' => [
+                    'title' => $message->getTitle(),
+                    'body' => $message->getBody(),
+                    'badge' => $message->getBadge(),
+                    'sound' => $message->getSound()
+                ],
+            ])
+        );
+    }
+
+}

--- a/tests/e2e/Push/PushyTest.php
+++ b/tests/e2e/Push/PushyTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\E2E;
+
+use Utopia\Messaging\Adapters\Push\Pushy as PushyAdapter;
+use Utopia\Messaging\Messages\Push;
+
+class PushyTest extends Base{
+    public function testSend(): void {
+        $secretKey = getenv('PUSHY_SECRET_KEY');
+
+        $adapter = new PushyAdapter($secretKey);
+
+        $to = getenv('PUSHY_SERVER_TO');
+
+        $message = new Push(
+            to: [$to],
+            title: 'TestTitle',
+            body: 'TestBody',
+            data: [
+                'some' => 'metadata',
+            ],
+            action: null,
+            sound: 'default',
+            icon: null,
+            color: null,
+            tag: null,
+            badge: '1'
+        );
+
+        $response = \json_decode($adapter->send($message));
+
+        $this->assertNotEmpty($response);
+        $this->assertEquals(1, $response->success);
+        $this->assertEquals(0, $response->failure);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds a new Push Adapter for sending push notification via Pushy.

## Test Plan

- SignIn and Create a new  Application on [Pushy](https://dashboard.pushy.me/apps)
- Add the following environment variables
   - PUSHY_SECRET_KEY: < APP_NAME > API Authentication Tab >
   - PUSHY_SERVER_TO: <userId e.g. 'test-user-id'>
- Run test against tests/e2e/Push/PushyTest.php

## Related PRs and Issues

Closes [appwrite/appwrite#6400](https://github.com/appwrite/appwrite/issues/6400)

### Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md)?
Yes

