### PR TITLE
Added SMSApi Messaging Adapter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,9 @@ jobs:
         VONAGE_API_SECRET: ${{ secrets.VONAGE_API_SECRET }}
         VONAGE_TO: ${{ secrets.VONAGE_TO }}
         VONAGE_FROM: ${{ secrets.VONAGE_FROM }}
+        SMSAPI_AUTH_TOKEN: ${{ secrets.SMSAPI_AUTH_TOKEN }}
+        SMSAPI_TO: ${{ secrets.SMSAPI_TO }}
+        SMSAPI_FROM: ${{ secrets.SMSAPI_FROM }}
       run: |
         docker compose up -d --build
         sleep 5

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ $messaging->send($message);
 - [x] [Sinch](https://www.sinch.com/)
 - [x] [Seven](https://www.seven.io/)
 - [ ] [SmsGlobal](https://www.smsglobal.com/)
+- [x] [SMSApi](https://www.smsapi.com/)
 
 ### Push
 - [x] [FCM](https://firebase.google.com/docs/cloud-messaging)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,9 @@ services:
     - VONAGE_API_SECRET
     - VONAGE_TO
     - VONAGE_FROM
+    - SMSAPI_AUTH_TOKEN
+    - SMSAPI_TO
+    - SMSAPI_FROM
     build:
       context: .
     volumes:

--- a/src/Utopia/Messaging/Adapters/SMS/SMSApi.php
+++ b/src/Utopia/Messaging/Adapters/SMS/SMSApi.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Utopia\Messaging\Adapters\SMS;
+
+use Utopia\Messaging\Adapters\SMS as SMSAdapter;
+use Utopia\Messaging\Messages\SMS;
+
+// Reference Material
+// https://www.smsapi.com/docs/#2-single-sms
+class SMSApi extends SMSAdapter
+{
+    /**
+     * @param  string  $apiToken SMSApi token
+     */
+    public function __construct(
+        private string $apiToken
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'SMSApi';
+    }
+
+    public function getMaxMessagesPerRequest(): int
+    {
+        return 1000;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Exception
+     */
+    protected function process(SMS $message): string
+    {
+        return $this->request(
+            method: 'POST',
+            url: "https://api.smsapi.com/sms.do",
+            headers: [
+                'Authorization: Bearer '.$this->apiToken,
+                'content-type: application/json',
+            ],
+            body: \json_encode([
+                'from' => $message->getFrom(),          //sendername made in https://ssl.smsapi.com/sms_settings/sendernames
+                'to' => $message->getTo()[0],           //destination number
+                'message' => $message->getContent(),    //message content
+            ]),
+        );
+    }
+}

--- a/tests/e2e/SMS/SMSApiTest.php
+++ b/tests/e2e/SMS/SMSApiTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\E2E;
+
+use Utopia\Messaging\Adapters\SMS\SMSApi;
+use Utopia\Messaging\Messages\SMS;
+
+class SMSApiTest extends Base
+{
+    /**
+     * @throws \Exception
+     */
+    public function testSendSMS()
+    {
+        // $sender = new SMSApi(getenv('SMSAPI_AUTH_TOKEN'));
+
+        // $message = new SMS(
+        //     to: [getenv('SMSAPI_TO')],
+        //     content: 'Test Content',
+        //     from: getenv('SMSAPI_FROM')
+        // );
+
+        // $response = $sender->send($message);
+        // $result = \json_decode($response, true);
+
+        // $this->assertEquals('success', $result['type']);
+
+        $this->markTestSkipped('SMSApi currenlty not available in INDIA.');
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR implements SMSApi messaging adapter

## Test Plan

To execute the SMSApi E2E test suite, you will need a SMSApi account with certain requirements. Please follow these steps:
1. Create a [SMSApi](https://www.smsapi.com/) account
2. Set up Sender Information
3. Create a token
4. Download this repository & install necessary package by 
``` 
composer install 
```
5. Run E2E test by replacing your TOKEN, DESTINATION_NUMBER & SENDERNAME in following command.
(Note: Go to tests/e2e/SMS/SMSApiTest.php file. Do un-comment the commented line & comment the markTestSkipped line [Line no:28])
```
SMSAPI_AUTH_TOKEN="TOKEN" SMSAPI_TO="DESTINATION_NUMBER" SMSAPI_FROM="SENDERNAME_FROM_SMSApi" ./vendor/bin/phpunit tests/e2e/SMS/SMSApiTest.php
```

## Related PRs and Issues

Closes: [#6402](https://github.com/appwrite/appwrite/issues/6402)

### Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md)?

Yes