### PR TITLE
Added Elastic Email Adapter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     - MAILGUN_API_KEY
     - MAILGUN_DOMAIN
     - SENDGRID_API_KEY
+    - ElasticEmail_API_KEY
     - FCM_SERVER_KEY
     - FCM_SERVER_TO
     - TWILIO_ACCOUNT_SID

--- a/src/Utopia/Messaging/Adapters/Email/ElasticEmail.php
+++ b/src/Utopia/Messaging/Adapters/Email/ElasticEmail.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Utopia\Messaging\Adapters\Email;
+
+use Utopia\Messaging\Adapters\Email as EmailAdapter;
+use Utopia\Messaging\Messages\Email;
+
+class ElasticEmail extends EmailAdapter
+{
+    /**
+     * @param  string  $apiKey Your ElasticEmail API key to authenticate with the API.
+     * @param  string  $domain Your ElasticEmail domain to send messages from.
+     */
+    public function __construct(
+        private string $apiKey,
+        private string $domain,
+        private bool $isEU = false
+    ) {
+    }
+
+    /**
+     * Get adapter name.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'ElasticEmail';
+    }
+
+    /**
+     * Get adapter description.
+     *
+     * @return int
+     */
+    public function getMaxMessagesPerRequest(): int
+    {
+        return 1000;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param Email $message
+     * @return string
+     *
+     * @throws \Exception
+     */
+    protected function process(Email $message): string
+    {
+        $domain = 'api.ElasticEmail.com';
+
+        $response = $this->request(
+            method: 'POST',
+            url: "https://$domain/v4/{$this->domain}/send",
+            headers: [
+                'Authorization: Basic '.base64_encode('api:'.$this->apiKey),
+            ],
+            body: http_build_query([
+                'apiKey' => $this->apiKey,
+                'from' => $message->getFrom(),
+                'fromName' => $message->getFromName(),
+                'subject' => $message->getSubject(),
+                'bodyHtml' => $message->isHtml() ? $message->getContent() : null,
+                'bodyText' => $message->isHtml() ? null : $message->getContent(),
+                'to' => implode(',', $message->getTo()),            ]),
+        );
+
+        return $response;
+    }
+}

--- a/tests/e2e/Email/ElasticEmailTest.php
+++ b/tests/e2e/Email/ElasticEmailTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\E2E;
+
+use Utopia\Messaging\Adapters\Email\ElasticEmail;
+use Utopia\Messaging\Messages\Email;
+
+class ElasticEmail extends Base
+{
+    /**
+     * @throws \Exception
+     */
+    public function testSendEmail()
+    {
+        $key = getenv('ElasticEmail_API_KEY');
+
+        $sender = new ElasticEmail(
+            apiKey: $key,
+
+        );
+
+        $to = getenv('TEST_EMAIL');
+        $subject = 'Test Subject';
+        $content = 'Test Content';
+        $from = 'sender@'.$domain;
+
+        $message = new Email(
+            to: [$to],
+            from: $from,
+            subject: $subject,
+            content: $content,
+        );
+
+        $result = (array) \json_decode($sender->send($message));
+
+        $this->assertArrayHasKey('transactionId', $result);
+        $this->assertArrayHasKey('message', $result);
+        $this->assertTrue(str_contains(strtolower($result['message']), 'queued'));
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR contains an implementation of the ElasticEmail transactional email adapter.

# Test Plan for Elastic Email Integration

This document outlines the steps to set up and test Elastic Email for your project.

## 1. Sign up for an Elastic Email Account

If you don't already have an Elastic Email account, visit [Elastic Email's website](https://elasticemail.com) and sign up for an account. Follow the on-screen instructions to complete the registration.

## 2. Obtain Elastic Email API Credentials

After registering and logging into your Elastic Email account, you'll need to obtain your API credentials.

- In the Elastic Email dashboard, navigate to the API section.
- Generate an API Key if you don't already have one. Make sure to save it securely.

## 3. Install Relevant Dependencies

Before testing your project with Elastic Email, ensure that you have the necessary dependencies installed.

## PHP Extensions
You'll need specific PHP extensions to interact with Elastic Email. Use the following commands to install them on Linux-based systems:
```bash
sudo apt update && sudo apt install php-curl php-mbstring php-xml
```

## Composer Dependencies
If you haven't already installed Composer, follow the installation instructions at [Composer's website](https://getcomposer.org/download/).

Next, install the project dependencies using Composer. In your project directory, run:

```bash
composer install
```

## 4. Set Environment Variables
To run tests with Elastic Email, you'll need to set up relevant environment variables.

**ELASTIC_EMAIL_API_KEY**: Your Elastic Email API key.
**TEST_EMAIL**: The recipient's email address.
**TEST_EMAIL_FROM**: The sender's email address.
You can set these environment variables in your system or in a configuration file specific to your project.

## 5. Test the Project
With all the preparations in place, you can now test your project's integration with Elastic Email.

Use the following command to initiate the test:

```bash
ELASTIC_EMAIL_API_KEY=<YOUR_ELASTIC_EMAIL_API_KEY> TEST_EMAIL=<YOUR_RECIPIENT_EMAIL> TEST_EMAIL_FROM=<YOUR_SENDER_EMAIL> ./vendor
```

Replace <YOUR_ELASTIC_EMAIL_API_KEY>, <YOUR_RECIPIENT_EMAIL>, and <YOUR_SENDER_EMAIL> with your actual Elastic Email API key, recipient email address, and sender email address.

Ensure that your project interacts with Elastic Email as expected and that emails are sent successfully.

## Related PRs and Issues

closes: appwrite/appwrite#6387

### Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md)?

YES
