### PR TITLE
Added BulkSMS Messaging adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ $messaging->send($message);
 - [x] [Sinch](https://www.sinch.com/)
 - [x] [Seven](https://www.seven.io/)
 - [ ] [SmsGlobal](https://www.smsglobal.com/)
+- [x] [BulkSMS](https://www.bulksms.com/)
 
 ### Push
 - [x] [FCM](https://firebase.google.com/docs/cloud-messaging)

--- a/src/Utopia/Messaging/Adapters/SMS/BulkSMS.php
+++ b/src/Utopia/Messaging/Adapters/SMS/BulkSMS.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Utopia\Messaging\Adapters\SMS;
+
+use Utopia\Messaging\Adapters\SMS as SMSAdapter;
+use Utopia\Messaging\Messages\SMS;
+
+// Reference Material
+// https://www.bulksms.com/developer/json/v1/#tag/Message
+class BulkSMS extends SMSAdapter
+{
+    /**
+     * @param  string  $username BulkSMS Username
+     * @param  string  $password BulkSMS Password
+     */
+    public function __construct(
+        private string $username,
+        private string $password
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'BulkSMS';
+    }
+
+    public function getMaxMessagesPerRequest(): int
+    {
+        return 500;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Exception
+     */
+    protected function process(SMS $message): string
+    {
+        return $this->request(
+            method: 'POST',
+            url: "https://api.bulksms.com/v1/messages?auto-unicode=true&longMessageMaxParts=30",
+            headers: [
+                'content-type: application/json',
+                'Authorization: Basic '.base64_encode("{$this->username}:{$this->password}")
+            ],
+            body: \json_encode([
+                'from' => $message->getFrom(),
+                'to' => $message->getTo(),
+                'body' => $message->getContent()
+            ]),
+        );
+    }
+}

--- a/tests/e2e/SMS/BulkSMSTest.php
+++ b/tests/e2e/SMS/BulkSMSTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\E2E;
+
+class BulkSMSTest extends Base
+{
+    /**
+     * @throws \Exception
+     */
+    public function testSendSMS()
+    {
+        $this->markTestSkipped('Bulksms requires you to create an account in order to enable bulk SMS');
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR implements BulkSMS messaging adapter

## Test Plan

1. Create Your BulkSMS Account

2. Sign up for an account on [BulkSMS](https://www.bulksms.com/).

3. Set up Sender Information

4. Set up your phone number

5. Send the message.

![Screenshot 2023-10-09 235907](https://github.com/utopia-php/messaging/assets/93239528/9e8d59b6-415f-4195-9e97-52dfcf997273)
Image shows the messages sent from a user's account

## Related PRs and Issues

Close [#6385](https://github.com/appwrite/appwrite/issues/6385)

### Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md)?

Yes