### PR TITLE
Add Netcore Email adapter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
         VONAGE_API_SECRET: ${{ secrets.VONAGE_API_SECRET }}
         VONAGE_TO: ${{ secrets.VONAGE_TO }}
         VONAGE_FROM: ${{ secrets.VONAGE_FROM }}
+        NETCORE_API_KEY: ${{ secrets.NETCORE_API_KEY }}
       run: |
         docker compose up -d --build
         sleep 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     - VONAGE_API_SECRET
     - VONAGE_TO
     - VONAGE_FROM
+    - NETCORE_API_KEY
     build:
       context: .
     volumes:

--- a/src/Utopia/Messaging/Adapters/Email/Netcore.php
+++ b/src/Utopia/Messaging/Adapters/Email/Netcore.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Utopia\Messaging\Adapters\Email;
+
+use Utopia\Messaging\Adapters\Email as EmailAdapter;
+use Utopia\Messaging\Messages\Email;
+
+class Netcore extends EmailAdapter
+{
+    /**
+     * @param  string  $apiKey Your Netcore API key to authenticate with the API. (Ref: https://cpaasdocs.netcorecloud.com/docs/pepipost-api/ZG9jOjQyMTU3NjQ0-authentication)
+     * @param  bool  $isEU Whether to use the EU domain or not.
+     */
+    public function __construct(
+        private string $apiKey,
+        private bool $isEU = false
+    ) {
+    }
+
+    /**
+     * Get adapter name.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Netcore';
+    }
+
+    /**
+     * Get adapter description.
+     *
+     * @return int
+     */
+    public function getMaxMessagesPerRequest(): int
+    {
+        return 1000;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Exception
+     */
+    protected function process(Email $message): string
+    {
+        $usDomain = 'emailapi.netcorecloud.net';
+        $euDomain = 'apieu.netcorecloud.net';
+
+        $domain = $this->isEU ? $euDomain : $usDomain;
+
+        $body = [
+            'to' => \implode(',', $message->getTo()),
+            'from' => $message->getFrom(),
+            'subject' => $message->getSubject(),
+            'content' => [
+                'type' => $message->isHtml() ? 'html' : 'amp',
+                'value' => $message->getContent(),
+            ],
+        ];
+
+        $response = $this->request(
+            method: 'POST',
+            url: "https://$domain/v5.1/mail/send",
+            headers: [
+                'apiKey: '.base64_encode('api:'.$this->apiKey),
+                'Accept: application/json',
+                'Content-Type: application/json',
+            ],
+            body: \json_encode($body)
+        );
+
+        return $response;
+    }
+}

--- a/tests/e2e/Email/NetcoreTest.php
+++ b/tests/e2e/Email/NetcoreTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\E2E;
+
+use Utopia\Messaging\Adapters\Email\Netcore;
+use Utopia\Messaging\Messages\Email;
+
+class NetcoreTest extends Base
+{
+    /**
+     * @throws \Exception
+     */
+    public function testSendPlainTextEmail()
+    {
+        $this->markTestSkipped('Netcore credentials not set.');
+
+        $key = getenv('NETCORE_API_KEY');
+        $sender = new Netcore(
+            apiKey: $key,
+            isEU: false
+        );
+
+        $to = getenv('TEST_EMAIL');
+        $subject = 'Test Subject';
+        $content = 'Test Content';
+        $from = getenv('TEST_FROM_EMAIL');
+
+        $message = new Email(
+            to: [$to],
+            from: $from,
+            subject: $subject,
+            content: $content,
+        );
+
+        $result = (array) \json_decode($sender->send($message));
+
+        $this->assertArrayHasKey('data', $result);
+        $this->assertEquals('OK', $result['message']);
+        $this->assertEquals('success', $result['status']);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md

Happy contributing!

-->

As I'm still yet to receive the test account and credits from Netcore I'm making this a draft PR, as I wrote the code and tests by referring to their [API docs](https://cpaasdocs.netcorecloud.com/docs/pepipost-api/c2d895762f832-send-an-email)

## What does this PR do?

This PR adds Netcore email adapter along with tests.

## Test Plan

`Check the first line I'll update once I get a Netcore account or if someone already has one test account that can be really helpful to test, As their email API doesn't include direct free testing account signups currently`
![image](https://github.com/utopia-php/messaging/assets/42518907/1450bfad-3493-438c-96b8-aa2609c883df)


## Related PRs and Issues

Closes https://github.com/appwrite/appwrite/issues/6394

- https://github.com/appwrite/appwrite/issues/6394

### Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md)?

Yes