### PR TITLE
Use default false bool sandbox instead of endpoint param

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   "require-dev": {
     "phpunit/phpunit": "9.6.*",
     "phpmailer/phpmailer": "6.8.*",
-    "laravel/pint": "^1.2"
+    "laravel/pint": "1.13.*"
   },
   "config": {
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5ecbd865cbd7f14e7819fb79643573be",
+    "content-hash": "31345eedeb45973edbfc61a2c6b722b6",
     "packages": [],
     "packages-dev": [
         {
@@ -79,16 +79,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.2.0",
+            "version": "v1.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "1d276e4c803397a26cc337df908f55c2a4e90d86"
+                "reference": "3e3d2ab01c7d8b484c18e6100ecf53639c744fa7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/1d276e4c803397a26cc337df908f55c2a4e90d86",
-                "reference": "1d276e4c803397a26cc337df908f55c2a4e90d86",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/3e3d2ab01c7d8b484c18e6100ecf53639c744fa7",
+                "reference": "3e3d2ab01c7d8b484c18e6100ecf53639c744fa7",
                 "shasum": ""
             },
             "require": {
@@ -96,16 +96,16 @@
                 "ext-mbstring": "*",
                 "ext-tokenizer": "*",
                 "ext-xml": "*",
-                "php": "^8.0"
+                "php": "^8.1.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.11.0",
-                "illuminate/view": "^9.27",
-                "laravel-zero/framework": "^9.1.3",
-                "mockery/mockery": "^1.5.0",
-                "nunomaduro/larastan": "^2.2",
-                "nunomaduro/termwind": "^1.14.0",
-                "pestphp/pest": "^1.22.1"
+                "friendsofphp/php-cs-fixer": "^3.38.0",
+                "illuminate/view": "^10.30.1",
+                "laravel-zero/framework": "^10.3.0",
+                "mockery/mockery": "^1.6.6",
+                "nunomaduro/larastan": "^2.6.4",
+                "nunomaduro/termwind": "^1.15.1",
+                "pestphp/pest": "^2.24.2"
             },
             "bin": [
                 "builds/pint"
@@ -141,7 +141,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2022-09-13T15:07:15+00:00"
+            "time": "2023-11-07T17:59:57+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1898,5 +1898,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Utopia/Messaging/Adapter.php
+++ b/src/Utopia/Messaging/Adapter.php
@@ -6,29 +6,21 @@ abstract class Adapter
 {
     /**
      * Get the name of the adapter.
-     *
-     * @return string
      */
     abstract public function getName(): string;
 
     /**
      * Get the type of the adapter.
-     *
-     * @return string
      */
     abstract public function getType(): string;
 
     /**
      * Get the type of the message the adapter can send.
-     *
-     * @return string
      */
     abstract public function getMessageType(): string;
 
     /**
      * Get the maximum number of messages that can be sent in a single request.
-     *
-     * @return int
      */
     abstract public function getMaxMessagesPerRequest(): int;
 
@@ -55,7 +47,7 @@ abstract class Adapter
         string $method,
         string $url,
         array $headers = [],
-        ?string $body = null,
+        string $body = null,
     ): string {
         $ch = \curl_init();
 

--- a/src/Utopia/Messaging/Adapters/Email/Mailgun.php
+++ b/src/Utopia/Messaging/Adapters/Email/Mailgun.php
@@ -20,8 +20,6 @@ class Mailgun extends EmailAdapter
 
     /**
      * Get adapter name.
-     *
-     * @return string
      */
     public function getName(): string
     {
@@ -30,8 +28,6 @@ class Mailgun extends EmailAdapter
 
     /**
      * Get adapter description.
-     *
-     * @return int
      */
     public function getMaxMessagesPerRequest(): int
     {

--- a/src/Utopia/Messaging/Adapters/Email/Sendgrid.php
+++ b/src/Utopia/Messaging/Adapters/Email/Sendgrid.php
@@ -17,8 +17,6 @@ class Sendgrid extends EmailAdapter
 
     /**
      * Get adapter name.
-     *
-     * @return string
      */
     public function getName(): string
     {
@@ -27,8 +25,6 @@ class Sendgrid extends EmailAdapter
 
     /**
      * Get max messages per request.
-     *
-     * @return int
      */
     public function getMaxMessagesPerRequest(): int
     {
@@ -38,8 +34,6 @@ class Sendgrid extends EmailAdapter
     /**
      * {@inheritdoc}
      *
-     * @param  Email  $message
-     * @return string
      *
      * @throws Exception
      */

--- a/src/Utopia/Messaging/Adapters/Push/APNS.php
+++ b/src/Utopia/Messaging/Adapters/Push/APNS.php
@@ -9,26 +9,19 @@ use Utopia\Messaging\Messages\Push;
 class APNS extends PushAdapter
 {
     /**
-     * @param  string  $authKey
-     * @param  string  $authKeyId
-     * @param  string  $teamId
-     * @param  string  $bundleId
-     * @param  bool    $sandbox
      * @return void
      */
     public function __construct(
-      private string $authKey,
-      private string $authKeyId,
-      private string $teamId,
-      private string $bundleId,
-      private bool $sandbox = false
+        private string $authKey,
+        private string $authKeyId,
+        private string $teamId,
+        private string $bundleId,
+        private bool $sandbox = false
     ) {
     }
 
     /**
      * Get adapter name.
-     *
-     * @return string
      */
     public function getName(): string
     {
@@ -37,8 +30,6 @@ class APNS extends PushAdapter
 
     /**
      * Get max messages per request.
-     *
-     * @return int
      */
     public function getMaxMessagesPerRequest(): int
     {
@@ -48,8 +39,6 @@ class APNS extends PushAdapter
     /**
      * {@inheritdoc}
      *
-     * @param  Push  $message
-     * @return string
      *
      * @throws Exception
      */
@@ -184,7 +173,6 @@ class APNS extends PushAdapter
     /**
      * Generate JWT.
      *
-     * @return string
      *
      * @throws Exception
      */

--- a/src/Utopia/Messaging/Adapters/Push/APNS.php
+++ b/src/Utopia/Messaging/Adapters/Push/APNS.php
@@ -13,7 +13,7 @@ class APNS extends PushAdapter
      * @param  string  $authKeyId
      * @param  string  $teamId
      * @param  string  $bundleId
-     * @param  string  $endpoint
+     * @param  bool    $sandbox
      * @return void
      */
     public function __construct(
@@ -21,7 +21,7 @@ class APNS extends PushAdapter
       private string $authKeyId,
       private string $teamId,
       private string $bundleId,
-      private string $endpoint
+      private bool $sandbox = false
     ) {
     }
 
@@ -98,13 +98,18 @@ class APNS extends PushAdapter
         ]);
 
         $response = '';
+        $endpoint = 'api.push.apple.com';
+
+        if ($this->sandbox) {
+            $endpoint = 'api.development.push.apple.com';
+        }
 
         $mh = curl_multi_init();
         $handles = [];
 
         // Create a handle for each request
         foreach ($to as $token) {
-            curl_setopt($ch, CURLOPT_URL, $this->endpoint.'/3/device/'.$token);
+            curl_setopt($ch, CURLOPT_URL, $endpoint.'/3/device/'.$token);
 
             $handle = curl_copy_handle($ch);
             curl_multi_add_handle($mh, $handle);

--- a/src/Utopia/Messaging/Adapters/Push/APNS.php
+++ b/src/Utopia/Messaging/Adapters/Push/APNS.php
@@ -98,10 +98,10 @@ class APNS extends PushAdapter
         ]);
 
         $response = '';
-        $endpoint = 'api.push.apple.com';
+        $endpoint = 'https://api.push.apple.com';
 
         if ($this->sandbox) {
-            $endpoint = 'api.development.push.apple.com';
+            $endpoint = 'https://api.development.push.apple.com';
         }
 
         $mh = curl_multi_init();

--- a/src/Utopia/Messaging/Adapters/Push/FCM.php
+++ b/src/Utopia/Messaging/Adapters/Push/FCM.php
@@ -17,8 +17,6 @@ class FCM extends PushAdapter
 
     /**
      * Get adapter name.
-     *
-     * @return string
      */
     public function getName(): string
     {
@@ -27,8 +25,6 @@ class FCM extends PushAdapter
 
     /**
      * Get max messages per request.
-     *
-     * @return int
      */
     public function getMaxMessagesPerRequest(): int
     {

--- a/src/Utopia/Messaging/Messages/Email.php
+++ b/src/Utopia/Messaging/Messages/Email.php
@@ -24,49 +24,31 @@ class Email implements Message
     ) {
     }
 
-    /**
-     * @return array
-     */
     public function getTo(): array
     {
         return $this->to;
     }
 
-    /**
-     * @return string
-     */
     public function getSubject(): string
     {
         return $this->subject;
     }
 
-    /**
-     * @return string
-     */
     public function getContent(): string
     {
         return $this->content;
     }
 
-    /**
-     * @return string|null
-     */
     public function getFrom(): ?string
     {
         return $this->from;
     }
 
-    /**
-     * @return array|null
-     */
     public function getAttachments(): ?array
     {
         return $this->attachments;
     }
 
-    /**
-     * @return bool
-     */
     public function isHtml(): bool
     {
         return $this->html;

--- a/src/Utopia/Messaging/Messages/Push.php
+++ b/src/Utopia/Messaging/Messages/Push.php
@@ -32,9 +32,6 @@ class Push implements Message
     ) {
     }
 
-    /**
-     * @return array
-     */
     public function getTo(): array
     {
         return $this->to;
@@ -45,73 +42,46 @@ class Push implements Message
         return null;
     }
 
-    /**
-     * @return string
-     */
     public function getTitle(): string
     {
         return $this->title;
     }
 
-    /**
-     * @return string
-     */
     public function getBody(): string
     {
         return $this->body;
     }
 
-    /**
-     * @return array|null
-     */
     public function getData(): ?array
     {
         return $this->data;
     }
 
-    /**
-     * @return string|null
-     */
     public function getAction(): ?string
     {
         return $this->action;
     }
 
-    /**
-     * @return string|null
-     */
     public function getSound(): ?string
     {
         return $this->sound;
     }
 
-    /**
-     * @return string|null
-     */
     public function getIcon(): ?string
     {
         return $this->icon;
     }
 
-    /**
-     * @return string|null
-     */
     public function getColor(): ?string
     {
         return $this->color;
     }
 
-    /**
-     * @return string|null
-     */
     public function getTag(): ?string
     {
         return $this->tag;
     }
 
-    /**
-     * @return string|null
-     */
     public function getBadge(): ?string
     {
         return $this->badge;

--- a/src/Utopia/Messaging/Messages/SMS.php
+++ b/src/Utopia/Messaging/Messages/SMS.php
@@ -14,33 +14,21 @@ class SMS implements Message
     ) {
     }
 
-    /**
-     * @return array
-     */
     public function getTo(): array
     {
         return $this->to;
     }
 
-    /**
-     * @return string
-     */
     public function getContent(): string
     {
         return $this->content;
     }
 
-    /**
-     * @return string|null
-     */
     public function getFrom(): ?string
     {
         return $this->from;
     }
 
-    /**
-     * @return array|null
-     */
     public function getAttachments(): ?array
     {
         return $this->attachments;

--- a/tests/e2e/Email/EmailTest.php
+++ b/tests/e2e/Email/EmailTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Tests\E2E;
+namespace Tests\E2E\Email;
 
+use Tests\E2E\Base;
 use Utopia\Messaging\Adapters\Email\Mock;
 use Utopia\Messaging\Messages\Email;
 

--- a/tests/e2e/Email/MailgunTest.php
+++ b/tests/e2e/Email/MailgunTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Tests\E2E;
+namespace Tests\E2E\Email;
 
+use Tests\E2E\Base;
 use Utopia\Messaging\Adapters\Email\Mailgun;
 use Utopia\Messaging\Messages\Email;
 

--- a/tests/e2e/Email/SendgridTest.php
+++ b/tests/e2e/Email/SendgridTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\E2E\Email;
 
+use Tests\E2E\Base;
 use Utopia\Messaging\Adapters\Email\Sendgrid;
 use Utopia\Messaging\Messages\Email;
 

--- a/tests/e2e/Email/SendgridTest.php
+++ b/tests/e2e/Email/SendgridTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\E2E;
+namespace Tests\E2E\Email;
 
 use Utopia\Messaging\Adapters\Email\Sendgrid;
 use Utopia\Messaging\Messages\Email;

--- a/tests/e2e/Push/APNSTest.php
+++ b/tests/e2e/Push/APNSTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\E2E\Push;
 
+use Tests\E2E\Base;
 use Utopia\Messaging\Adapters\Push\APNS as APNSAdapter;
 use Utopia\Messaging\Messages\Push;
 

--- a/tests/e2e/Push/APNSTest.php
+++ b/tests/e2e/Push/APNSTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\E2E;
+namespace Tests\E2E\Push;
 
 use Utopia\Messaging\Adapters\Push\APNS as APNSAdapter;
 use Utopia\Messaging\Messages\Push;

--- a/tests/e2e/Push/FCMTest.php
+++ b/tests/e2e/Push/FCMTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Tests\E2E;
+namespace Tests\E2E\Push;
 
+use Tests\E2E\Base;
 use Utopia\Messaging\Adapters\Push\FCM as FCMAdapter;
 use Utopia\Messaging\Messages\Push;
 

--- a/tests/e2e/SMS/GEOSMS/CallingCodeTest.php
+++ b/tests/e2e/SMS/GEOSMS/CallingCodeTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Tests\E2E;
+namespace Tests\E2E\SMS\GEOSMS;
 
+use Tests\E2E\Base;
 use Utopia\Messaging\Adapters\SMS\GEOSMS\CallingCode;
 
 class CallingCodeTest extends Base

--- a/tests/e2e/SMS/GEOSMSTest.php
+++ b/tests/e2e/SMS/GEOSMSTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Tests\E2E;
+namespace Tests\E2E\SMS;
 
+use Tests\E2E\Base;
 use Utopia\Messaging\Adapters\SMS as SMSAdapter;
 use Utopia\Messaging\Adapters\SMS\GEOSMS;
 use Utopia\Messaging\Adapters\SMS\GEOSMS\CallingCode;

--- a/tests/e2e/SMS/Msg91Test.php
+++ b/tests/e2e/SMS/Msg91Test.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Tests\E2E;
+namespace Tests\E2E\SMS;
 
+use Tests\E2E\Base;
 use Utopia\Messaging\Adapters\SMS\Msg91;
 use Utopia\Messaging\Messages\SMS;
 

--- a/tests/e2e/SMS/SMSTest.php
+++ b/tests/e2e/SMS/SMSTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Tests\E2E;
+namespace Tests\E2E\SMS;
 
+use Tests\E2E\Base;
 use Utopia\Messaging\Adapters\SMS\Mock;
 use Utopia\Messaging\Messages\SMS;
 

--- a/tests/e2e/SMS/TelesignTest.php
+++ b/tests/e2e/SMS/TelesignTest.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Tests\E2E;
+namespace Tests\E2E\SMS;
+
+use Tests\E2E\Base;
 
 class TelesignTest extends Base
 {

--- a/tests/e2e/SMS/TelnyxTest.php
+++ b/tests/e2e/SMS/TelnyxTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Tests\E2E;
+namespace Tests\E2E\SMS;
 
+use Tests\E2E\Base;
 use Utopia\Messaging\Adapters\SMS\Telnyx;
 use Utopia\Messaging\Messages\SMS;
 

--- a/tests/e2e/SMS/TwilioTest.php
+++ b/tests/e2e/SMS/TwilioTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Tests\E2E;
+namespace Tests\E2E\SMS;
 
+use Tests\E2E\Base;
 use Utopia\Messaging\Adapters\SMS\Twilio;
 use Utopia\Messaging\Messages\SMS;
 

--- a/tests/e2e/SMS/VonageTest.php
+++ b/tests/e2e/SMS/VonageTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Tests\E2E;
+namespace Tests\E2E\SMS;
 
+use Tests\E2E\Base;
 use Utopia\Messaging\Adapters\SMS\Vonage;
 use Utopia\Messaging\Messages\SMS;
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Replace APNS endpoint with a `sandbox` parameter that defaults to false. When true, will use the APNS sandbox endpoint instead of production.

## Test Plan

Existing tests

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md)?

(Write your answer here.)
