### PR TITLE
feat: filter country code in fast2sms adapter

### DIFF
--- a/src/Utopia/Messaging/Adapter/SMS/Fast2SMS.php
+++ b/src/Utopia/Messaging/Adapter/SMS/Fast2SMS.php
@@ -3,6 +3,7 @@
 namespace Utopia\Messaging\Adapter\SMS;
 
 use Utopia\Messaging\Adapter\SMS as SMSAdapter;
+use Utopia\Messaging\Adapter\SMS\GEOSMS\CallingCode;
 use Utopia\Messaging\Messages\SMS as SMSMessage;
 use Utopia\Messaging\Response;
 
@@ -65,7 +66,7 @@ class Fast2SMS extends SMSAdapter
     protected function process(SMSMessage $message): array
     {
         $numbers = array_map(
-            fn($number) => $this->removeCountryCode($number),
+            fn ($number) => $this->removeCountryCode($number),
             $message->getTo()
         );
         $numbers = implode(',', $numbers);
@@ -118,21 +119,20 @@ class Fast2SMS extends SMSAdapter
     /**
      * Removes country code from a phone number
      * Fast2SMS expects Indian phone numbers without the country code
-     * 
+     *
      * @param string $number Phone number with potential country code
      * @return string Phone number without country code
      */
-    private function removeCountryCode(string $number): string 
+    private function removeCountryCode(string $number): string
     {
         // Remove any non-digit characters
         $digits = preg_replace('/[^0-9]/', '', $number);
-        
-        // Extract country code using CallingCode utility
-        $code = \Utopia\Messaging\Adapter\SMS\GEOSMS\CallingCode::fromPhoneNumber($number);
+
+        $code = CallingCode::fromPhoneNumber($number);
         if ($code !== null) {
             return substr($digits, strlen($code));
         }
-        
+
         return $digits;
     }
 }

--- a/src/Utopia/Messaging/Adapter/SMS/Fast2SMS.php
+++ b/src/Utopia/Messaging/Adapter/SMS/Fast2SMS.php
@@ -23,7 +23,6 @@ class Fast2SMS extends SMSAdapter
      * @param string $apiKey Your Fast2SMS API authorization key
      * @param string $senderId Your 3-6 letter DLT approved Sender ID (e.g., "FSTSMS"). Required for DLT route
      * @param string $messageId Your DLT approved Message ID template. Required for DLT route
-     * @param string[] $variableValues Array of values for variables in DLT template message. Optional for DLT route
      * @param bool $useDLT Whether to use DLT route (true) or Quick SMS route (false)
      *
      * @see https://docs.fast2sms.com/#dlt-sms
@@ -33,7 +32,6 @@ class Fast2SMS extends SMSAdapter
         private string $apiKey,
         private string $senderId = '',
         private string $messageId = '',
-        private array $variableValues = [],
         private bool $useDLT = false
     ) {
     }
@@ -83,10 +81,7 @@ class Fast2SMS extends SMSAdapter
             $payload['route'] = 'dlt';
             $payload['sender_id'] = $this->senderId;
             $payload['message'] = $this->messageId;
-
-            if (!empty($this->variableValues)) {
-                $payload['variables_values'] = implode('|', $this->variableValues);
-            }
+            $payload['variables_values'] = $message->getContent();
         } else {
             $payload['route'] = 'q';
             $payload['message'] = $message->getContent();

--- a/src/Utopia/Messaging/Adapter/SMS/Fast2SMS.php
+++ b/src/Utopia/Messaging/Adapter/SMS/Fast2SMS.php
@@ -71,8 +71,6 @@ class Fast2SMS extends SMSAdapter
         );
         $numbers = implode(',', $numbers);
 
-        var_dump($numbers);
-
         $payload = [
             'numbers' => $numbers,
             'flash' => 0,

--- a/tests/Messaging/Adapter/SMS/Fast2SMSTest.php
+++ b/tests/Messaging/Adapter/SMS/Fast2SMSTest.php
@@ -37,13 +37,12 @@ class Fast2SMSTest extends Base
             apiKey: getenv('FAST2SMS_API_KEY'),
             senderId: getenv('FAST2SMS_SENDER_ID'),
             messageId: getenv('FAST2SMS_MESSAGE_ID'),
-            variableValues: ['12345'],
             useDLT: true
         );
 
         $message = new SMS(
             to: [getenv('FAST2SMS_TO')],
-            content: '', // Content is ignored when using DLT based messaging
+            content: '12345',
         );
 
         $response = $sender->send($message);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fast2SMS requires its numbers to not have any country code prefix. In this PR we filter the recipients to ensure the country code is removed

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md)?

(Write your answer here.)
