### PR TITLE
fix: sending of batch emails without exposing all recipient emails

### DIFF
--- a/src/Utopia/Messaging/Adapter/Email/Mailgun.php
+++ b/src/Utopia/Messaging/Adapter/Email/Mailgun.php
@@ -39,6 +39,10 @@ class Mailgun extends EmailAdapter
 
     /**
      * {@inheritdoc}
+     *
+     * Uses Mailgun's batch sending feature to send multiple emails at once.
+     *
+     * @link https://documentation.mailgun.com/docs/mailgun/user-manual/sending-messages/#batch-sending
      */
     protected function process(EmailMessage $message): array
     {
@@ -56,7 +60,6 @@ class Mailgun extends EmailAdapter
             'h:Reply-To: '."{$message->getReplyToName()}<{$message->getReplyToEmail()}>",
         ];
 
-        // sending batch emails, https://documentation.mailgun.com/docs/mailgun/user-manual/sending-messages/#batch-sending
         if (\count($message->getTo()) > 1) {
             $body['recipient-variables'] = json_encode(array_fill_keys($message->getTo(), []));
         }

--- a/src/Utopia/Messaging/Adapter/Email/Mailgun.php
+++ b/src/Utopia/Messaging/Adapter/Email/Mailgun.php
@@ -55,7 +55,7 @@ class Mailgun extends EmailAdapter
             'html' => $message->isHtml() ? $message->getContent() : null,
             'h:Reply-To: '."{$message->getReplyToName()}<{$message->getReplyToEmail()}>",
         ];
-        
+
         // sending batch emails, https://documentation.mailgun.com/docs/mailgun/user-manual/sending-messages/#batch-sending
         if (\count($message->getTo()) > 1) {
             $body['recipient-variables'] = json_encode(array_fill_keys($message->getTo(), []));

--- a/src/Utopia/Messaging/Adapter/Email/Mailgun.php
+++ b/src/Utopia/Messaging/Adapter/Email/Mailgun.php
@@ -55,6 +55,11 @@ class Mailgun extends EmailAdapter
             'html' => $message->isHtml() ? $message->getContent() : null,
             'h:Reply-To: '."{$message->getReplyToName()}<{$message->getReplyToEmail()}>",
         ];
+        
+        // sending batch emails, https://documentation.mailgun.com/docs/mailgun/user-manual/sending-messages/#batch-sending
+        if (\count($message->getTo()) > 1) {
+            $body['recipient-variables'] = json_encode(array_fill_keys($message->getTo(), []));
+        }
 
         if (!\is_null($message->getCC())) {
             foreach ($message->getCC() as $cc) {

--- a/src/Utopia/Messaging/Adapter/Email/Sendgrid.php
+++ b/src/Utopia/Messaging/Adapter/Email/Sendgrid.php
@@ -100,8 +100,6 @@ class Sendgrid extends EmailAdapter
             }
         }
 
-        fwrite(STDOUT, json_encode($personalizations, JSON_PRETTY_PRINT));
-
         $body = [
             'personalizations' => $personalizations,
             'reply_to' => [

--- a/src/Utopia/Messaging/Adapter/Email/Sendgrid.php
+++ b/src/Utopia/Messaging/Adapter/Email/Sendgrid.php
@@ -35,11 +35,14 @@ class Sendgrid extends EmailAdapter
     }
 
     /**
-     * {@inheritdoc}
-     */
+    * {@inheritdoc}
+    *
+    * Uses Sendgrid's personalization recipient variables to send multiple emails at once.
+    *
+    * @link https://www.twilio.com/docs/sendgrid/for-developers/sending-email/personalizations#-Sending-Two-Different-Emails-to-Two-Different-Groups-of-Recipients
+    */
     protected function process(EmailMessage $message): array
     {
-        // https://www.twilio.com/docs/sendgrid/for-developers/sending-email/personalizations#-Sending-Two-Different-Emails-to-Two-Different-Groups-of-Recipients
         $personalizations = \array_map(
             fn ($to) => [
                 'to' => [['email' => $to]],
@@ -48,34 +51,30 @@ class Sendgrid extends EmailAdapter
             $message->getTo()
         );
 
-        if (!\is_null($message->getCC())) {
-            foreach ($message->getCC() as $cc) {
-                if (!empty($cc['name'])) {
-                    $personalizations[0]['cc'][] = [
-                        'name' => $cc['name'],
-                        'email' => $cc['email'],
-                    ];
-                } else {
-                    $personalizations[0]['cc'][] = [
-                        'email' => $cc['email'],
-                    ];
+        if (!empty($message->getCC())) {
+            foreach ($personalizations as &$personalization) {
+                foreach ($message->getCC() as $cc) {
+                    $entry = ['email' => $cc['email']];
+                    if (!empty($cc['name'])) {
+                        $entry['name'] = $cc['name'];
+                    }
+                    $personalization['cc'][] = $entry;
                 }
             }
+            unset($personalization);
         }
 
-        if (!\is_null($message->getBCC())) {
-            foreach ($message->getBCC() as $bcc) {
-                if (!empty($bcc['name'])) {
-                    $personalizations[0]['bcc'][] = [
-                        'name' => $bcc['name'],
-                        'email' => $bcc['email'],
-                    ];
-                } else {
-                    $personalizations[0]['bcc'][] = [
-                        'email' => $bcc['email'],
-                    ];
+        if (!empty($message->getBCC())) {
+            foreach ($personalizations as &$personalization) {
+                foreach ($message->getBCC() as $bcc) {
+                    $entry = ['email' => $bcc['email']];
+                    if (!empty($bcc['name'])) {
+                        $entry['name'] = $bcc['name'];
+                    }
+                    $personalization['bcc'][] = $entry;
                 }
             }
+            unset($personalization);
         }
 
         $attachments = [];
@@ -100,6 +99,8 @@ class Sendgrid extends EmailAdapter
                 ];
             }
         }
+
+        fwrite(STDOUT, json_encode($personalizations, JSON_PRETTY_PRINT));
 
         $body = [
             'personalizations' => $personalizations,

--- a/src/Utopia/Messaging/Adapter/Email/Sendgrid.php
+++ b/src/Utopia/Messaging/Adapter/Email/Sendgrid.php
@@ -39,6 +39,7 @@ class Sendgrid extends EmailAdapter
      */
     protected function process(EmailMessage $message): array
     {
+        // https://www.twilio.com/docs/sendgrid/for-developers/sending-email/personalizations#-Sending-Two-Different-Emails-to-Two-Different-Groups-of-Recipients
         $personalizations = \array_map(
             fn ($to) => [
                 'to' => [['email' => $to]],

--- a/src/Utopia/Messaging/Adapter/Email/Sendgrid.php
+++ b/src/Utopia/Messaging/Adapter/Email/Sendgrid.php
@@ -39,15 +39,13 @@ class Sendgrid extends EmailAdapter
      */
     protected function process(EmailMessage $message): array
     {
-        $personalizations = [
-            [
-                'to' => \array_map(
-                    fn ($to) => ['email' => $to],
-                    $message->getTo()
-                ),
+        $personalizations = \array_map(
+            fn ($to) => [
+                'to' => [['email' => $to]],
                 'subject' => $message->getSubject(),
             ],
-        ];
+            $message->getTo()
+        );
 
         if (!\is_null($message->getCC())) {
             foreach ($message->getCC() as $cc) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR addresses the data security concerns while sending of batch emails that exposes all the other recipients emails to every recipient.

## Test Plan

setup:

<img width="697" alt="Screenshot 2025-01-12 at 8 23 14 PM" src="https://github.com/user-attachments/assets/f9af2831-a6ce-4c18-82c2-5307b12d1dd8" />

mailgun working:

<img width="616" alt="Screenshot 2025-01-12 at 8 22 56 PM" src="https://github.com/user-attachments/assets/f8e5299d-a1f6-40af-b534-d322e6e27e94" />

sendgrid working:

<img width="485" alt="Screenshot 2025-01-14 at 1 19 18 PM" src="https://github.com/user-attachments/assets/37318b3a-2c30-4564-a322-3ca5730073f2" />

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/8261

### Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md)?

Yes.
