### PR TITLE
Feat: Customizable SMS mock

### DIFF
--- a/src/Utopia/Messaging/Adapter/SMS/Mock.php
+++ b/src/Utopia/Messaging/Adapter/SMS/Mock.php
@@ -10,6 +10,8 @@ class Mock extends SMSAdapter
 {
     protected const NAME = 'Mock';
 
+    protected string $url = 'http://request-catcher:5000/mock-sms';
+
     /**
      * @param  string  $user User ID
      * @param  string  $secret User secret
@@ -23,6 +25,17 @@ class Mock extends SMSAdapter
     public function getName(): string
     {
         return static::NAME;
+    }
+
+    public function getEndpoint(): string
+    {
+        return $this->url;
+    }
+
+    public function setEndpoint(string $url): self
+    {
+        $this->url = $url;
+        return $this;
     }
 
     public function getMaxMessagesPerRequest(): int
@@ -43,7 +56,7 @@ class Mock extends SMSAdapter
 
         $result = $this->request(
             method: 'POST',
-            url: 'http://request-catcher:5000/mock-sms',
+            url: $this->url,
             headers: [
                 'Content-Type: application/json',
                 "X-Username: {$this->user}",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

adds methods to customize sms mock endpoint, to allow to point to different containers, for example splitting sms mock and  webhooks mock

## Test Plan

PR in Appwrite

## Related PRs and Issues

https://github.com/appwrite/appwrite/pull/10066

### Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md)?

Yes
