### PR TITLE
feat: smtp timeout

### DIFF
--- a/src/Utopia/Messaging/Adapter/Email/SMTP.php
+++ b/src/Utopia/Messaging/Adapter/Email/SMTP.php
@@ -19,6 +19,7 @@ class SMTP extends EmailAdapter
      * @param string $smtpSecure SMTP Secure prefix. Can be '', 'ssl' or 'tls'
      * @param bool $smtpAutoTLS Enable/disable SMTP AutoTLS feature. Defaults to false.
      * @param string $xMailer The value to use for the X-Mailer header.
+     * @param int $timeout SMTP timeout in seconds.
      */
     public function __construct(
         private string $host,
@@ -28,6 +29,7 @@ class SMTP extends EmailAdapter
         private string $smtpSecure = '',
         private bool $smtpAutoTLS = false,
         private string $xMailer = '',
+        private int $timeout = 30
     ) {
         if (!\in_array($this->smtpSecure, ['', 'ssl', 'tls'])) {
             throw new \InvalidArgumentException('Invalid SMTP secure prefix. Must be "", "ssl" or "tls"');
@@ -60,6 +62,7 @@ class SMTP extends EmailAdapter
         $mail->Password = $this->password;
         $mail->SMTPSecure = $this->smtpSecure;
         $mail->SMTPAutoTLS = $this->smtpAutoTLS;
+        $mail->Timeout = $this->timeout;
         $mail->CharSet = 'UTF-8';
         $mail->Subject = $message->getSubject();
         $mail->Body = $message->getContent();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the SMTP timeout duration when sending emails. The default timeout is now set to 30 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->