### PR TITLE
chore: remove default recepient

### DIFF
--- a/src/Utopia/Messaging/Adapter/Email/SMTP.php
+++ b/src/Utopia/Messaging/Adapter/Email/SMTP.php
@@ -75,14 +75,6 @@ class SMTP extends EmailAdapter
         $mail->AltBody = \strip_tags($mail->AltBody);
         $mail->AltBody = \trim($mail->AltBody);
 
-        if (empty($message->getTo())) {
-            if (empty($message->getBCC()) && empty($message->getDefaultRecipient())) {
-                throw new \Exception('Email requires either "to" recipients or both BCC and a default recipient configurations');
-            }
-
-            $mail->addAddress($message->getDefaultRecipient());
-        }
-
         foreach ($message->getTo() as $to) {
             $mail->addAddress($to);
         }

--- a/src/Utopia/Messaging/Messages/Email.php
+++ b/src/Utopia/Messaging/Messages/Email.php
@@ -19,7 +19,6 @@ class Email implements Message
      * @param  string|null  $replyToEmail The email address of the reply to.
      * @param  array<Attachment>|null  $attachments The attachments of the email.
      * @param  bool  $html Whether the message is HTML or not.
-     * @param  string|null  $defaultRecipient The default recipient of the email.
      *
      * @throws \InvalidArgumentException
      */
@@ -35,7 +34,6 @@ class Email implements Message
         private ?array $bcc = null,
         private ?array $attachments = null,
         private bool $html = false,
-        private ?string $defaultRecipient = null
     ) {
         if (\is_null($this->replyToName)) {
             $this->replyToName = $this->fromName;
@@ -127,10 +125,5 @@ class Email implements Message
     public function isHtml(): bool
     {
         return $this->html;
-    }
-
-    public function getDefaultRecipient(): ?string
-    {
-        return $this->defaultRecipient;
     }
 }

--- a/tests/Messaging/Adapter/Email/SMTPTest.php
+++ b/tests/Messaging/Adapter/Email/SMTPTest.php
@@ -85,7 +85,6 @@ class SMTPTest extends Base
             port: 1025,
         );
 
-        $defaultRecipient = 'tester@localhost.test';
         $subject = 'Test Subject';
         $content = 'Test Content';
         $fromName = 'Test Sender';
@@ -104,7 +103,6 @@ class SMTPTest extends Base
             fromName: $fromName,
             fromEmail: $fromEmail,
             bcc: $bcc,
-            defaultRecipient: $defaultRecipient,
         );
 
         $response = $sender->send($message);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed implicit “default recipient” handling. Emails are now sent only to explicitly specified recipients (To/CC/BCC); no automatic fallback when To is empty.
  - Simplified email message API by removing support for a default recipient.
- Tests
  - Updated test cases to reflect the removal of default recipient behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->