### PR TITLE
Use `assertSame` in tests

### DIFF
--- a/tests/Messaging/Adapter/Base.php
+++ b/tests/Messaging/Adapter/Base.php
@@ -40,8 +40,8 @@ class Base extends TestCase
      */
     protected function assertResponse(array $response): void
     {
-        $this->assertEquals(1, $response['deliveredTo'], \var_export($response, true));
-        $this->assertEquals('', $response['results'][0]['error'], \var_export($response, true));
-        $this->assertEquals('success', $response['results'][0]['status'], \var_export($response, true));
+        $this->assertSame(1, $response['deliveredTo'], \var_export($response, true));
+        $this->assertSame('', $response['results'][0]['error'], \var_export($response, true));
+        $this->assertSame('success', $response['results'][0]['status'], \var_export($response, true));
     }
 }

--- a/tests/Messaging/Adapter/Chat/DiscordTest.php
+++ b/tests/Messaging/Adapter/Chat/DiscordTest.php
@@ -82,6 +82,6 @@ class DiscordTest extends Base
         $property = $reflector->getProperty('webhookId');
         $property->setAccessible(true);
 
-        $this->assertEquals($webhookId, $property->getValue($discord), 'Webhook ID was not correctly extracted');
+        $this->assertSame($webhookId, $property->getValue($discord), 'Webhook ID was not correctly extracted');
     }
 }

--- a/tests/Messaging/Adapter/Email/EmailTest.php
+++ b/tests/Messaging/Adapter/Email/EmailTest.php
@@ -35,12 +35,12 @@ class EmailTest extends Base
         $lastEmail = $this->getLastEmail();
 
         $this->assertResponse($response);
-        $this->assertEquals($to, $lastEmail['to'][0]['address']);
-        $this->assertEquals($fromEmail, $lastEmail['from'][0]['address']);
-        $this->assertEquals($fromName, $lastEmail['from'][0]['name']);
-        $this->assertEquals($subject, $lastEmail['subject']);
-        $this->assertEquals($content, \trim($lastEmail['text']));
-        $this->assertEquals($cc[0]['email'], $lastEmail['cc'][0]['address']);
-        $this->assertEquals($bcc[0]['email'], $lastEmail['envelope']['to'][2]['address']);
+        $this->assertSame($to, $lastEmail['to'][0]['address']);
+        $this->assertSame($fromEmail, $lastEmail['from'][0]['address']);
+        $this->assertSame($fromName, $lastEmail['from'][0]['name']);
+        $this->assertSame($subject, $lastEmail['subject']);
+        $this->assertSame($content, \trim($lastEmail['text']));
+        $this->assertSame($cc[0]['email'], $lastEmail['cc'][0]['address']);
+        $this->assertSame($bcc[0]['email'], $lastEmail['envelope']['to'][2]['address']);
     }
 }

--- a/tests/Messaging/Adapter/Email/ResendTest.php
+++ b/tests/Messaging/Adapter/Email/ResendTest.php
@@ -108,11 +108,11 @@ class ResendTest extends Base
 
         $response = $this->sender->send($message);
 
-        $this->assertEquals(2, $response['deliveredTo'], \var_export($response, true));
-        $this->assertEquals('', $response['results'][0]['error'], \var_export($response, true));
-        $this->assertEquals('success', $response['results'][0]['status'], \var_export($response, true));
-        $this->assertEquals('', $response['results'][1]['error'], \var_export($response, true));
-        $this->assertEquals('success', $response['results'][1]['status'], \var_export($response, true));
+        $this->assertSame(2, $response['deliveredTo'], \var_export($response, true));
+        $this->assertSame('', $response['results'][0]['error'], \var_export($response, true));
+        $this->assertSame('success', $response['results'][0]['status'], \var_export($response, true));
+        $this->assertSame('', $response['results'][1]['error'], \var_export($response, true));
+        $this->assertSame('success', $response['results'][1]['status'], \var_export($response, true));
     }
 
     public function testSendEmailWithAttachmentsThrowsException(): void

--- a/tests/Messaging/Adapter/Email/SMTPTest.php
+++ b/tests/Messaging/Adapter/Email/SMTPTest.php
@@ -35,10 +35,10 @@ class SMTPTest extends Base
         $lastEmail = $this->getLastEmail();
 
         $this->assertResponse($response);
-        $this->assertEquals($to, $lastEmail['to'][0]['address']);
-        $this->assertEquals($fromEmail, $lastEmail['from'][0]['address']);
-        $this->assertEquals($subject, $lastEmail['subject']);
-        $this->assertEquals($content, \trim($lastEmail['text']));
+        $this->assertSame($to, $lastEmail['to'][0]['address']);
+        $this->assertSame($fromEmail, $lastEmail['from'][0]['address']);
+        $this->assertSame($subject, $lastEmail['subject']);
+        $this->assertSame($content, \trim($lastEmail['text']));
     }
 
     public function testSendEmailWithAttachment(): void
@@ -72,10 +72,10 @@ class SMTPTest extends Base
         $lastEmail = $this->getLastEmail();
 
         $this->assertResponse($response);
-        $this->assertEquals($to, $lastEmail['to'][0]['address']);
-        $this->assertEquals($fromEmail, $lastEmail['from'][0]['address']);
-        $this->assertEquals($subject, $lastEmail['subject']);
-        $this->assertEquals($content, \trim($lastEmail['text']));
+        $this->assertSame($to, $lastEmail['to'][0]['address']);
+        $this->assertSame($fromEmail, $lastEmail['from'][0]['address']);
+        $this->assertSame($subject, $lastEmail['subject']);
+        $this->assertSame($content, \trim($lastEmail['text']));
     }
 
     public function testSendEmailOnlyBCC(): void
@@ -110,8 +110,8 @@ class SMTPTest extends Base
         $lastEmail = $this->getLastEmail();
 
         $this->assertResponse($response);
-        $this->assertEquals($fromEmail, $lastEmail['from'][0]['address']);
-        $this->assertEquals($subject, $lastEmail['subject']);
-        $this->assertEquals($content, \trim($lastEmail['text']));
+        $this->assertSame($fromEmail, $lastEmail['from'][0]['address']);
+        $this->assertSame($subject, $lastEmail['subject']);
+        $this->assertSame($content, \trim($lastEmail['text']));
     }
 }

--- a/tests/Messaging/Adapter/SMS/GEOSMS/CallingCodeTest.php
+++ b/tests/Messaging/Adapter/SMS/GEOSMS/CallingCodeTest.php
@@ -9,11 +9,11 @@ class CallingCodeTest extends Base
 {
     public function testFromPhoneNumber(): void
     {
-        $this->assertEquals(CallingCode::NORTH_AMERICA, CallingCode::fromPhoneNumber('+11234567890'));
-        $this->assertEquals(CallingCode::INDIA, CallingCode::fromPhoneNumber('+911234567890'));
-        $this->assertEquals(CallingCode::ISRAEL, CallingCode::fromPhoneNumber('9721234567890'));
-        $this->assertEquals(CallingCode::UNITED_ARAB_EMIRATES, CallingCode::fromPhoneNumber('009711234567890'));
-        $this->assertEquals(CallingCode::UNITED_KINGDOM, CallingCode::fromPhoneNumber('011441234567890'));
-        $this->assertEquals(null, CallingCode::fromPhoneNumber('2'));
+        $this->assertSame(CallingCode::NORTH_AMERICA, CallingCode::fromPhoneNumber('+11234567890'));
+        $this->assertSame(CallingCode::INDIA, CallingCode::fromPhoneNumber('+911234567890'));
+        $this->assertSame(CallingCode::ISRAEL, CallingCode::fromPhoneNumber('9721234567890'));
+        $this->assertSame(CallingCode::UNITED_ARAB_EMIRATES, CallingCode::fromPhoneNumber('009711234567890'));
+        $this->assertSame(CallingCode::UNITED_KINGDOM, CallingCode::fromPhoneNumber('011441234567890'));
+        $this->assertSame(null, CallingCode::fromPhoneNumber('2'));
     }
 }

--- a/tests/Messaging/Adapter/SMS/GEOSMSTest.php
+++ b/tests/Messaging/Adapter/SMS/GEOSMSTest.php
@@ -29,8 +29,8 @@ class GEOSMSTest extends Base
 
         $result = $adapter->send($message);
 
-        $this->assertEquals(1, count($result));
-        $this->assertEquals('success', $result['default']['results'][0]['status']);
+        $this->assertSame(1, count($result));
+        $this->assertSame('success', $result['default']['results'][0]['status']);
     }
 
     public function testSendSMSUsingLocalAdapter(): void
@@ -54,8 +54,8 @@ class GEOSMSTest extends Base
 
         $result = $adapter->send($message);
 
-        $this->assertEquals(1, count($result));
-        $this->assertEquals('success', $result['local']['results'][0]['status']);
+        $this->assertSame(1, count($result));
+        $this->assertSame('success', $result['local']['results'][0]['status']);
     }
 
     public function testSendSMSUsingLocalAdapterAndDefault(): void
@@ -81,9 +81,9 @@ class GEOSMSTest extends Base
 
         $result = $adapter->send($message);
 
-        $this->assertEquals(2, count($result));
-        $this->assertEquals('success', $result['local']['results'][0]['status']);
-        $this->assertEquals('success', $result['default']['results'][0]['status']);
+        $this->assertSame(2, count($result));
+        $this->assertSame('success', $result['local']['results'][0]['status']);
+        $this->assertSame('success', $result['default']['results'][0]['status']);
     }
 
     public function testSendSMSUsingGroupedLocalAdapter(): void
@@ -108,7 +108,7 @@ class GEOSMSTest extends Base
 
         $result = $adapter->send($message);
 
-        $this->assertEquals(1, count($result));
-        $this->assertEquals('success', $result['local']['results'][0]['status']);
+        $this->assertSame(1, count($result));
+        $this->assertSame('success', $result['local']['results'][0]['status']);
     }
 }

--- a/tests/Messaging/Adapter/SMS/SMSTest.php
+++ b/tests/Messaging/Adapter/SMS/SMSTest.php
@@ -25,14 +25,14 @@ class SMSTest extends Base
 
         $smsRequest = $this->getLastRequest();
 
-        $this->assertEquals('http://request-catcher:5000/mock-sms', $smsRequest['url']);
-        $this->assertEquals('Appwrite Mock Message Sender', $smsRequest['headers']['User-Agent']);
-        $this->assertEquals('username', $smsRequest['headers']['X-Username']);
-        $this->assertEquals('password', $smsRequest['headers']['X-Key']);
-        $this->assertEquals('POST', $smsRequest['method']);
-        $this->assertEquals('+987654321', $smsRequest['data']['from']);
-        $this->assertEquals('+123456789', $smsRequest['data']['to']);
-        $this->assertEquals(98, $sender->getCountryCode($smsRequest['data']['from']));
-        $this->assertEquals(1, $sender->getCountryCode($smsRequest['data']['to']));
+        $this->assertSame('http://request-catcher:5000/mock-sms', $smsRequest['url']);
+        $this->assertSame('Appwrite Mock Message Sender', $smsRequest['headers']['User-Agent']);
+        $this->assertSame('username', $smsRequest['headers']['X-Username']);
+        $this->assertSame('password', $smsRequest['headers']['X-Key']);
+        $this->assertSame('POST', $smsRequest['method']);
+        $this->assertSame('+987654321', $smsRequest['data']['from']);
+        $this->assertSame('+123456789', $smsRequest['data']['to']);
+        $this->assertSame(98, $sender->getCountryCode($smsRequest['data']['from']));
+        $this->assertSame(1, $sender->getCountryCode($smsRequest['data']['to']));
     }
 }

--- a/tests/Messaging/Adapter/SMS/TelnyxTest.php
+++ b/tests/Messaging/Adapter/SMS/TelnyxTest.php
@@ -20,8 +20,8 @@ class TelnyxTest extends Base
         // );
 
         // $result = $sender->send($message);
-
-        // $this->assertEquals('success', $result["type"]);
+        //
+        // $this->assertSame('success', $result["type"]);
 
         $this->markTestSkipped('Telnyx had no testing numbers available at this time.');
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened test assertions across messaging adapter modules to enforce stricter type and value matching, ensuring more comprehensive validation of response handling and data processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->