### PR TITLE
feat: add attachment support to Resend adapter

### DIFF
--- a/src/Utopia/Messaging/Adapter/Email/Resend.php
+++ b/src/Utopia/Messaging/Adapter/Email/Resend.php
@@ -35,9 +35,33 @@ class Resend extends EmailAdapter
      */
     protected function process(EmailMessage $message): array
     {
-        // Resend doesn't support attachments yet
+        $attachments = [];
         if (! \is_null($message->getAttachments()) && ! empty($message->getAttachments())) {
-            throw new \Exception('Resend does not support attachments at this time');
+            $size = 0;
+            foreach ($message->getAttachments() as $attachment) {
+                if ($attachment->getContent() !== null) {
+                    $size += \strlen($attachment->getContent());
+                } else {
+                    $size += \filesize($attachment->getPath());
+                }
+            }
+
+            if ($size > self::MAX_ATTACHMENT_BYTES) {
+                throw new \Exception('Total attachment size exceeds '.self::MAX_ATTACHMENT_BYTES.' bytes');
+            }
+
+            foreach ($message->getAttachments() as $attachment) {
+                if ($attachment->getContent() !== null) {
+                    $content = \base64_encode($attachment->getContent());
+                } else {
+                    $content = \base64_encode(\file_get_contents($attachment->getPath()));
+                }
+
+                $attachments[] = [
+                    'filename' => $attachment->getName(),
+                    'content' => $content,
+                ];
+            }
         }
 
         $response = new Response($this->getType());
@@ -76,6 +100,10 @@ class Resend extends EmailAdapter
                 if (! empty($ccList)) {
                     $email['cc'] = $ccList;
                 }
+            }
+
+            if (! empty($attachments)) {
+                $email['attachments'] = $attachments;
             }
 
             if (! \is_null($message->getBCC()) && ! empty($message->getBCC())) {

--- a/src/Utopia/Messaging/Adapter/Email/Resend.php
+++ b/src/Utopia/Messaging/Adapter/Email/Resend.php
@@ -42,7 +42,11 @@ class Resend extends EmailAdapter
                 if ($attachment->getContent() !== null) {
                     $size += \strlen($attachment->getContent());
                 } else {
-                    $size += \filesize($attachment->getPath());
+                    $fileSize = \filesize($attachment->getPath());
+                    if ($fileSize === false) {
+                        throw new \Exception('Failed to read attachment file: '.$attachment->getPath());
+                    }
+                    $size += $fileSize;
                 }
             }
 
@@ -54,12 +58,17 @@ class Resend extends EmailAdapter
                 if ($attachment->getContent() !== null) {
                     $content = \base64_encode($attachment->getContent());
                 } else {
-                    $content = \base64_encode(\file_get_contents($attachment->getPath()));
+                    $data = \file_get_contents($attachment->getPath());
+                    if ($data === false) {
+                        throw new \Exception('Failed to read attachment file: '.$attachment->getPath());
+                    }
+                    $content = \base64_encode($data);
                 }
 
                 $attachments[] = [
                     'filename' => $attachment->getName(),
                     'content' => $content,
+                    'content_type' => $attachment->getType(),
                 ];
             }
         }

--- a/tests/Messaging/Adapter/Email/ResendTest.php
+++ b/tests/Messaging/Adapter/Email/ResendTest.php
@@ -115,26 +115,65 @@ class ResendTest extends Base
         $this->assertEquals('success', $response['results'][1]['status'], \var_export($response, true));
     }
 
-    public function testSendEmailWithAttachmentsThrowsException(): void
+    public function testSendEmailWithFileAttachment(): void
     {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Resend does not support attachments at this time');
-
-        $to = $this->testEmail;
-        $subject = 'Test Subject';
-        $content = 'Test Content';
-        $fromEmail = $this->testEmail;
-
         $message = new Email(
-            to: [$to],
-            subject: $subject,
-            content: $content,
+            to: [$this->testEmail],
+            subject: 'Test File Attachment',
+            content: 'Test Content with file attachment',
             fromName: 'Test Sender',
-            fromEmail: $fromEmail,
+            fromEmail: $this->testEmail,
             attachments: [new Attachment(
                 name: 'image.png',
                 path: __DIR__.'/../../../assets/image.png',
                 type: 'image/png'
+            )],
+        );
+
+        $response = $this->sender->send($message);
+
+        $this->assertResponse($response);
+    }
+
+    public function testSendEmailWithStringAttachment(): void
+    {
+        $message = new Email(
+            to: [$this->testEmail],
+            subject: 'Test String Attachment',
+            content: 'Test Content with string attachment',
+            fromName: 'Test Sender',
+            fromEmail: $this->testEmail,
+            attachments: [new Attachment(
+                name: 'test.txt',
+                path: '',
+                type: 'text/plain',
+                content: 'Hello, this is a test attachment.',
+            )],
+        );
+
+        $response = $this->sender->send($message);
+
+        $this->assertResponse($response);
+    }
+
+    public function testSendEmailWithAttachmentExceedingMaxSize(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Total attachment size exceeds');
+
+        $largeContent = \str_repeat('x', 25 * 1024 * 1024 + 1);
+
+        $message = new Email(
+            to: [$this->testEmail],
+            subject: 'Test Oversized Attachment',
+            content: 'Test Content',
+            fromName: 'Test Sender',
+            fromEmail: $this->testEmail,
+            attachments: [new Attachment(
+                name: 'large.bin',
+                path: '',
+                type: 'application/octet-stream',
+                content: $largeContent,
             )],
         );
 


### PR DESCRIPTION
## Summary
- Remove the exception that blocked attachments in the Resend email adapter
- Add attachment handling: base64-encode file-based (`getPath()`) or string-based (`getContent()`) attachments and include them in the Resend API payload
- Validate total attachment size against `MAX_ATTACHMENT_BYTES` (25MB), consistent with the SMTP adapter

## Test plan
- [x] `testSendEmailWithFileAttachment` — sends email with a file-path-based attachment
- [x] `testSendEmailWithStringAttachment` — sends email with raw string content attachment
- [x] `testSendEmailWithAttachmentExceedingMaxSize` — verifies 25MB limit throws exception (passes locally)
- [x] Existing Resend tests remain unaffected