### PR TITLE
Remove deprecated curl_close calls

### DIFF
--- a/src/Utopia/Messaging/Adapter.php
+++ b/src/Utopia/Messaging/Adapter.php
@@ -115,7 +115,6 @@ abstract class Adapter
 
         $response = \curl_exec($ch);
 
-
         try {
             $response = \json_decode($response, true, flags: JSON_THROW_ON_ERROR);
         } catch (\JsonException) {

--- a/src/Utopia/Messaging/Adapter.php
+++ b/src/Utopia/Messaging/Adapter.php
@@ -115,7 +115,6 @@ abstract class Adapter
 
         $response = \curl_exec($ch);
 
-        \curl_close($ch);
 
         try {
             $response = \json_decode($response, true, flags: JSON_THROW_ON_ERROR);
@@ -250,7 +249,6 @@ abstract class Adapter
             ];
 
             \curl_multi_remove_handle($mh, $ch);
-            \curl_close($ch);
         }
 
         \curl_multi_close($mh);


### PR DESCRIPTION
## What does this PR do?

Removes calls to `curl_close()`. Since PHP 8.0, cURL handles are `CurlHandle` objects and `curl_close()` no longer has an effect; handles are released by object lifetime instead. Removing these calls avoids noisy PHP 8.5 deprecation warnings without changing behavior for supported PHP versions.

## Test Plan

- Ran `php -l` on changed PHP files where applicable.
- Confirmed no `curl_close(...)` calls remain in this repository.

## Related PRs and Issues

N/A

### Have you read the Contributing Guidelines on issues?

Yes.
