### PR TITLE
Fix PHP 8.5 curl_close()/curl_multi_close() deprecation

### DIFF
--- a/src/Utopia/Messaging/Adapter.php
+++ b/src/Utopia/Messaging/Adapter.php
@@ -115,8 +115,6 @@ abstract class Adapter
 
         $response = \curl_exec($ch);
 
-        \curl_close($ch);
-
         try {
             $response = \json_decode($response, true, flags: JSON_THROW_ON_ERROR);
         } catch (\JsonException) {
@@ -250,10 +248,8 @@ abstract class Adapter
             ];
 
             \curl_multi_remove_handle($mh, $ch);
-            \curl_close($ch);
         }
 
-        \curl_multi_close($mh);
         \curl_share_close($sh);
 
         return $responses;


### PR DESCRIPTION
## Summary
- Remove no-op `\curl_close($ch)` and `\curl_multi_close($mh)` calls in `Messaging\Adapter` that trigger `Deprecated` notices on PHP 8.5.

## Why
Both functions have been no-ops since PHP 8.0 and are now formally deprecated in 8.5. Handles are freed when their variables go out of scope.

## Test plan
- [x] `composer lint` (Pint) — pass
- [x] `composer analyse` (PHPStan L6) — pass