### PR TITLE
fix(Resend): send attachments via per-message endpoint

### DIFF
--- a/src/Utopia/Messaging/Adapter/Email/Resend.php
+++ b/src/Utopia/Messaging/Adapter/Email/Resend.php
@@ -10,6 +10,8 @@ class Resend extends EmailAdapter
 {
     protected const NAME = 'Resend';
 
+    protected const MAX_ATTACHMENT_BYTES = 40 * 1024 * 1024;
+
     /**
      * @param  string  $apiKey  Your Resend API key to authenticate with the API.
      */
@@ -29,9 +31,8 @@ class Resend extends EmailAdapter
     }
 
     /**
-     * Uses Resend's batch sending API to send multiple emails at once.
-     *
      * @link https://resend.com/docs/api-reference/emails/send-batch-emails
+     * @link https://resend.com/docs/api-reference/emails/send-email
      */
     protected function process(EmailMessage $message): array
     {
@@ -77,7 +78,7 @@ class Resend extends EmailAdapter
 
         $emails = [];
         foreach ($message->getTo() as $to) {
-            $toFormatted = !empty($to['name'])
+            $toFormatted = ! empty($to['name'])
                 ? "{$to['name']} <{$to['email']}>"
                 : $to['email'];
 
@@ -133,11 +134,25 @@ class Resend extends EmailAdapter
             'Content-Type: application/json',
         ];
 
+        if (! empty($attachments)) {
+            return $this->sendIndividually($message, $emails, $headers, $response);
+        }
+
+        return $this->sendBatch($message, $emails, $headers, $response);
+    }
+
+    /**
+     * @param  array<array<string, mixed>>  $emails
+     * @param  array<string>  $headers
+     * @return array{deliveredTo: int, type: string, results: array<array<string, mixed>>}
+     */
+    private function sendBatch(EmailMessage $message, array $emails, array $headers, Response $response): array
+    {
         $result = $this->request(
             method: 'POST',
             url: 'https://api.resend.com/emails/batch',
             headers: $headers,
-            body: $emails, // @phpstan-ignore-line
+            body: $emails,
         );
 
         $statusCode = $result['statusCode'];
@@ -145,7 +160,7 @@ class Resend extends EmailAdapter
         if ($statusCode === 200) {
             $responseData = $result['response'];
 
-            if (isset($responseData['errors']) && ! empty($responseData['errors'])) {
+            if (\is_array($responseData) && isset($responseData['errors']) && ! empty($responseData['errors'])) {
                 $failedIndices = [];
                 foreach ($responseData['errors'] as $error) {
                     $failedIndices[$error['index']] = $error['message'];
@@ -168,27 +183,13 @@ class Resend extends EmailAdapter
                 }
             }
         } elseif ($statusCode >= 400 && $statusCode < 500) {
-            $errorMessage = 'Unknown error';
-
-            if (\is_string($result['response'])) {
-                $errorMessage = $result['response'];
-            } elseif (isset($result['response']['message'])) {
-                $errorMessage = $result['response']['message'];
-            } elseif (isset($result['response']['error'])) {
-                $errorMessage = $result['response']['error'];
-            }
+            $errorMessage = $this->extractErrorMessage($result['response'], 'Unknown error');
 
             foreach ($message->getTo() as $to) {
                 $response->addResult($to['email'], $errorMessage);
             }
         } elseif ($statusCode >= 500) {
-            $errorMessage = 'Server error';
-
-            if (\is_string($result['response'])) {
-                $errorMessage = $result['response'];
-            } elseif (isset($result['response']['message'])) {
-                $errorMessage = $result['response']['message'];
-            }
+            $errorMessage = $this->extractErrorMessage($result['response'], 'Server error');
 
             foreach ($message->getTo() as $to) {
                 $response->addResult($to['email'], $errorMessage);
@@ -196,5 +197,66 @@ class Resend extends EmailAdapter
         }
 
         return $response->toArray();
+    }
+
+    /**
+     * @param  array<array<string, mixed>>  $emails
+     * @param  array<string>  $headers
+     * @return array{deliveredTo: int, type: string, results: array<array<string, mixed>>}
+     */
+    private function sendIndividually(EmailMessage $message, array $emails, array $headers, Response $response): array
+    {
+        $recipients = $message->getTo();
+        $deliveredTo = 0;
+
+        foreach ($emails as $index => $email) {
+            $to = $recipients[$index];
+
+            $result = $this->request(
+                method: 'POST',
+                url: 'https://api.resend.com/emails',
+                headers: $headers,
+                body: $email,
+            );
+
+            $statusCode = $result['statusCode'];
+
+            if ($statusCode >= 200 && $statusCode < 300) {
+                $response->addResult($to['email']);
+                $deliveredTo++;
+            } elseif ($statusCode >= 400 && $statusCode < 500) {
+                $errorMessage = $this->extractErrorMessage($result['response'], 'Unknown error');
+                $response->addResult($to['email'], $errorMessage);
+            } else {
+                $errorMessage = $this->extractErrorMessage($result['response'], 'Server error');
+                $response->addResult($to['email'], $errorMessage);
+            }
+        }
+
+        $response->setDeliveredTo($deliveredTo);
+
+        return $response->toArray();
+    }
+
+    /**
+     * @param  array<string, mixed>|string|null  $body
+     */
+    private function extractErrorMessage(array|string|null $body, string $default): string
+    {
+        if (\is_string($body)) {
+            return $body;
+        }
+
+        if (\is_array($body)) {
+            if (isset($body['message']) && \is_string($body['message'])) {
+                return $body['message'];
+            }
+
+            if (isset($body['error']) && \is_string($body['error'])) {
+                return $body['error'];
+            }
+        }
+
+        return $default;
     }
 }

--- a/tests/Messaging/Adapter/Email/ResendRoutingTest.php
+++ b/tests/Messaging/Adapter/Email/ResendRoutingTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Utopia\Tests\Adapter\Email;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Messaging\Adapter\Email\Resend;
+use Utopia\Messaging\Messages\Email;
+use Utopia\Messaging\Messages\Email\Attachment;
+
+class ResendRoutingTest extends TestCase
+{
+    public function testWithoutAttachmentsUsesBatchEndpoint(): void
+    {
+        $stub = new ResendStub('test-key');
+        $stub->stubResponses[] = ['statusCode' => 200, 'response' => []];
+
+        $message = new Email(
+            to: [['email' => 'a@example.com'], ['email' => 'b@example.com']],
+            subject: 'Subject',
+            content: 'Body',
+            fromName: 'Sender',
+            fromEmail: 'from@example.com',
+        );
+
+        $response = $stub->send($message);
+
+        $this->assertCount(1, $stub->capturedRequests);
+        $this->assertEquals('https://api.resend.com/emails/batch', $stub->capturedRequests[0]['url']);
+        $this->assertCount(2, $stub->capturedRequests[0]['body']);
+        $this->assertArrayNotHasKey('attachments', $stub->capturedRequests[0]['body'][0]);
+        $this->assertEquals(2, $response['deliveredTo']);
+    }
+
+    public function testWithAttachmentsUsesSingleEndpointPerRecipient(): void
+    {
+        $stub = new ResendStub('test-key');
+        $stub->stubResponses[] = ['statusCode' => 200, 'response' => ['id' => 'one']];
+        $stub->stubResponses[] = ['statusCode' => 200, 'response' => ['id' => 'two']];
+
+        $message = new Email(
+            to: [['email' => 'a@example.com'], ['email' => 'b@example.com']],
+            subject: 'Subject',
+            content: 'Body',
+            fromName: 'Sender',
+            fromEmail: 'from@example.com',
+            attachments: [new Attachment(
+                name: 'note.txt',
+                path: '',
+                type: 'text/plain',
+                content: 'hello',
+            )],
+        );
+
+        $response = $stub->send($message);
+
+        $this->assertCount(2, $stub->capturedRequests);
+
+        foreach ($stub->capturedRequests as $request) {
+            $this->assertEquals('https://api.resend.com/emails', $request['url']);
+            $this->assertArrayHasKey('attachments', $request['body']);
+            $this->assertCount(1, $request['body']['attachments']);
+            $this->assertEquals('note.txt', $request['body']['attachments'][0]['filename']);
+            $this->assertEquals('text/plain', $request['body']['attachments'][0]['content_type']);
+            $this->assertEquals(\base64_encode('hello'), $request['body']['attachments'][0]['content']);
+        }
+
+        $this->assertEquals(2, $response['deliveredTo']);
+    }
+
+    public function testPartialFailureWithAttachmentsAggregatesResults(): void
+    {
+        $stub = new ResendStub('test-key');
+        $stub->stubResponses[] = ['statusCode' => 200, 'response' => ['id' => 'one']];
+        $stub->stubResponses[] = ['statusCode' => 422, 'response' => ['message' => 'Invalid recipient']];
+
+        $message = new Email(
+            to: [['email' => 'a@example.com'], ['email' => 'b@example.com']],
+            subject: 'Subject',
+            content: 'Body',
+            fromName: 'Sender',
+            fromEmail: 'from@example.com',
+            attachments: [new Attachment(
+                name: 'note.txt',
+                path: '',
+                type: 'text/plain',
+                content: 'hello',
+            )],
+        );
+
+        $response = $stub->send($message);
+
+        $this->assertEquals(1, $response['deliveredTo']);
+        $this->assertEquals('success', $response['results'][0]['status']);
+        $this->assertEquals('failure', $response['results'][1]['status']);
+        $this->assertEquals('Invalid recipient', $response['results'][1]['error']);
+    }
+
+    public function testAttachmentExceedingMaxSizeThrows(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Total attachment size exceeds');
+
+        $stub = new ResendStub('test-key');
+
+        $message = new Email(
+            to: [['email' => 'a@example.com']],
+            subject: 'Subject',
+            content: 'Body',
+            fromName: 'Sender',
+            fromEmail: 'from@example.com',
+            attachments: [new Attachment(
+                name: 'large.bin',
+                path: '',
+                type: 'application/octet-stream',
+                content: \str_repeat('x', 40 * 1024 * 1024 + 1),
+            )],
+        );
+
+        $stub->send($message);
+    }
+}
+
+class ResendStub extends Resend
+{
+    /**
+     * @var array<array{url: string, method: string, headers: array<string>, body: mixed}>
+     */
+    public array $capturedRequests = [];
+
+    /**
+     * @var array<array{statusCode: int, response: array<string, mixed>|string|null}>
+     */
+    public array $stubResponses = [];
+
+    /**
+     * @param  array<string>  $headers
+     * @param  array<string, mixed>|null  $body
+     * @return array{url: string, statusCode: int, response: array<string, mixed>|string|null, error: string|null}
+     */
+    protected function request(
+        string $method,
+        string $url,
+        array $headers = [],
+        ?array $body = null,
+        int $timeout = 30,
+        int $connectTimeout = 10
+    ): array {
+        $this->capturedRequests[] = [
+            'method' => $method,
+            'url' => $url,
+            'headers' => $headers,
+            'body' => $body,
+        ];
+
+        $stub = \array_shift($this->stubResponses) ?? ['statusCode' => 200, 'response' => []];
+
+        return [
+            'url' => $url,
+            'statusCode' => $stub['statusCode'],
+            'response' => $stub['response'],
+            'error' => null,
+        ];
+    }
+}

--- a/tests/Messaging/Adapter/Email/ResendTest.php
+++ b/tests/Messaging/Adapter/Email/ResendTest.php
@@ -161,7 +161,7 @@ class ResendTest extends Base
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Total attachment size exceeds');
 
-        $largeContent = \str_repeat('x', 25 * 1024 * 1024 + 1);
+        $largeContent = \str_repeat('x', 40 * 1024 * 1024 + 1);
 
         $message = new Email(
             to: [$this->testEmail],


### PR DESCRIPTION
## Symptom

Sending an email with attachments via the `Resend` adapter currently results in the recipient receiving the email **without the attachments**. The attachments are silently dropped.

## Root cause

The adapter has always posted to Resend's batch endpoint `POST /emails/batch` for every send. That endpoint only accepts `from`, `to`, `subject`, `html`, `text`, `cc`, `bcc`, `reply_to`, `headers`, `scheduled_at`, `tags`, etc. — it does **not** support `attachments` or `scheduled_at` and silently ignores them. See [Send batch emails](https://resend.com/docs/api-reference/emails/send-batch-emails) — the docs explicitly call this out:

> The `attachments` and `scheduled_at` fields are not supported yet.

Resend's single-send endpoint `POST /emails` does support `attachments`. See [Send email](https://resend.com/docs/api-reference/emails/send-email).

## Fix

`Resend::process()` now branches on whether the message carries attachments:

- **No attachments** (existing behavior, preserved): one batch POST to `/emails/batch` with all recipients in one request — throughput unchanged for the common case.
- **With attachments** (new): one POST per recipient to `/emails`, each with the `attachments` array (`filename` / `content` / `content_type`) embedded. Per-recipient outcomes are aggregated into the same `Response` shape the batch path returns, so partial success is reported correctly.

The per-email size limit is also raised to **40 MB** to match Resend's documented single-send cap.

## Test plan

- [x] `composer lint` (Pint, PSR-12) passes
- [x] `composer analyse` (PHPStan level 6) passes
- [x] New `ResendRoutingTest` (4 tests, 25 assertions) passes — stubs `request()` and asserts:
  - no-attachment send hits `/emails/batch` once with all recipients in the body
  - attachment send hits `/emails` once per recipient with the `attachments` array shaped correctly
  - partial failure across recipients aggregates `deliveredTo` and per-recipient `status`/`error`
  - oversized payload (> 40 MB) throws before any HTTP call
- [ ] Manual end-to-end against Resend (out of scope for CI; existing integration tests in `ResendTest` continue to require `RESEND_API_KEY` and a verified test address)