### PR TITLE
fix(SES): create missing template instead of failing the send

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
         MAILGUN_DOMAIN: ${{ secrets.MAILGUN_DOMAIN }}
         RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
         SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+        SES_ACCESS_KEY: ${{ secrets.SES_ACCESS_KEY }}
+        SES_SECRET_KEY: ${{ secrets.SES_SECRET_KEY }}
+        SES_SESSION_TOKEN: ${{ secrets.SES_SESSION_TOKEN }}
         FCM_SERVICE_ACCOUNT_JSON: ${{ secrets.FCM_SERVICE_ACCOUNT_JSON }}
         FCM_TO: ${{ secrets.FCM_TO }}
         TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
@@ -53,6 +56,8 @@ jobs:
         INFORU_SENDER_ID: ${{ secrets.INFORU_SENDER_ID }}
 
         RESEND_TEST_EMAIL: ${{ vars.RESEND_TEST_EMAIL }}
+        SES_REGION: ${{ vars.SES_REGION }}
+        SES_TEST_EMAIL: ${{ vars.SES_TEST_EMAIL }}
       run: |
         docker compose up -d --build
         sleep 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,11 @@ services:
       - RESEND_API_KEY
       - RESEND_TEST_EMAIL
       - SENDGRID_API_KEY
+      - SES_ACCESS_KEY
+      - SES_SECRET_KEY
+      - SES_REGION
+      - SES_TEST_EMAIL
+      - SES_SESSION_TOKEN
       - FCM_SERVICE_ACCOUNT_JSON
       - FCM_TO
       - TWILIO_ACCOUNT_SID

--- a/src/Utopia/Messaging/Adapter.php
+++ b/src/Utopia/Messaging/Adapter.php
@@ -69,6 +69,7 @@ abstract class Adapter
      *     url: string,
      *     statusCode: int,
      *     response: array<string, mixed>|string|null,
+     *     headers: array<string, string>,
      *     error: string|null
      * }
      *
@@ -103,6 +104,8 @@ abstract class Adapter
             }
         }
 
+        $responseHeaders = [];
+
         \curl_setopt_array($ch, [
             CURLOPT_CUSTOMREQUEST => $method,
             CURLOPT_URL => $url,
@@ -111,6 +114,14 @@ abstract class Adapter
             CURLOPT_USERAGENT => "Appwrite {$this->getName()} Message Sender",
             CURLOPT_TIMEOUT => $timeout,
             CURLOPT_CONNECTTIMEOUT => $connectTimeout,
+            CURLOPT_HEADERFUNCTION => function ($ch, string $header) use (&$responseHeaders): int {
+                $parts = \explode(':', $header, 2);
+                if (\count($parts) === 2) {
+                    $responseHeaders[\strtolower(\trim($parts[0]))] = \trim($parts[1]);
+                }
+
+                return \strlen($header);
+            },
         ]);
 
         $response = \curl_exec($ch);
@@ -125,6 +136,7 @@ abstract class Adapter
             'url' => $url,
             'statusCode' => \curl_getinfo($ch, CURLINFO_RESPONSE_CODE),
             'response' => $response,
+            'headers' => $responseHeaders,
             'error' => \curl_error($ch),
         ];
     }

--- a/src/Utopia/Messaging/Adapter.php
+++ b/src/Utopia/Messaging/Adapter.php
@@ -152,6 +152,7 @@ abstract class Adapter
      *     url: string,
      *     statusCode: int,
      *     response: array<string, mixed>|null,
+     *     headers: array<string, string>,
      *     error: string|null
      * }>
      *
@@ -256,6 +257,12 @@ abstract class Adapter
                 'url' => \curl_getinfo($ch, CURLINFO_EFFECTIVE_URL),
                 'statusCode' => \curl_getinfo($ch, CURLINFO_RESPONSE_CODE),
                 'response' => $response,
+                // Kept in sync with request()'s shape. Response headers are not
+                // captured here: this path copies a configured handle with
+                // curl_copy_handle(), and copying a handle that carries a
+                // CURLOPT_HEADERFUNCTION closure segfaults. Wire up per-handle
+                // capture (without copy_handle) if a multi-path adapter needs it.
+                'headers' => [],
                 'error' => \curl_error($ch),
             ];
 

--- a/src/Utopia/Messaging/Adapter/Email/SES.php
+++ b/src/Utopia/Messaging/Adapter/Email/SES.php
@@ -266,7 +266,7 @@ class SES extends EmailAdapter
      * marked failed with the SES error. On success each recipient is mapped
      * from its corresponding BulkEmailEntryResults entry.
      *
-     * @param  array{url: string, statusCode: int, response: array<string, mixed>|string|null, error: string|null}  $result
+     * @param  array{url: string, statusCode: int, response: array<string, mixed>|string|null, headers: array<string, string>, error: string|null}  $result
      * @return array{deliveredTo: int, type: string, results: array<array<string, mixed>>}
      */
     private function parseBulkResult(EmailMessage $message, array $result, Response $response): array
@@ -383,14 +383,20 @@ class SES extends EmailAdapter
      * Whether a SendBulkEmail result indicates the referenced template is
      * missing, via either the top-level error or per-entry statuses.
      *
-     * @param  array{url: string, statusCode: int, response: array<string, mixed>|string|null, error: string|null}  $result
+     * @param  array{url: string, statusCode: int, response: array<string, mixed>|string|null, headers: array<string, string>, error: string|null}  $result
      */
     private function isTemplateMissing(array $result): bool
     {
         $errorType = $this->errorType($result);
         if ($errorType === 'NotFoundException' || $errorType === 'BadRequestException') {
-            $message = $this->errorMessage($result);
-            if (\stripos($message, 'template') !== false) {
+            // BadRequestException is generic, so confirm the message is about a
+            // missing template rather than another template error (e.g. invalid
+            // template content).
+            $message = \strtolower($this->errorMessage($result));
+            if (
+                \str_contains($message, 'template')
+                && (\str_contains($message, 'does not exist') || \str_contains($message, 'not found'))
+            ) {
                 return true;
             }
         }
@@ -521,7 +527,7 @@ class SES extends EmailAdapter
      * configured region.
      *
      * @param  array<string, mixed>  $body
-     * @return array{url: string, statusCode: int, response: array<string, mixed>|string|null, error: string|null}
+     * @return array{url: string, statusCode: int, response: array<string, mixed>|string|null, headers: array<string, string>, error: string|null}
      *
      * @throws \Exception
      */
@@ -652,7 +658,7 @@ class SES extends EmailAdapter
     /**
      * Extract a human-readable error message from a SES error response.
      *
-     * @param  array{url: string, statusCode: int, response: array<string, mixed>|string|null, error: string|null}  $result
+     * @param  array{url: string, statusCode: int, response: array<string, mixed>|string|null, headers: array<string, string>, error: string|null}  $result
      */
     private function errorMessage(array $result): string
     {
@@ -679,16 +685,25 @@ class SES extends EmailAdapter
     }
 
     /**
-     * Extract the SES error type. SES signals the type either via the
-     * x-amzn-ErrorType header (not available here) or a `__type` body field,
-     * e.g. "AlreadyExistsException" or "NotFoundException".
+     * Extract the SES error type, e.g. "AlreadyExistsException" or
+     * "NotFoundException".
      *
-     * @param  array{url: string, statusCode: int, response: array<string, mixed>|string|null, error: string|null}  $result
+     * SES API v2 uses the AWS REST-JSON protocol, which reports the exception
+     * type in the x-amzn-ErrorType response header, not the body. The header
+     * value can carry a trailing ":<location>" which is stripped. Older AWS
+     * JSON-protocol responses instead carry it in a `__type` (optionally
+     * "prefix#Type") or `code` body field, which is used as a fallback.
+     *
+     * @param  array{url: string, statusCode: int, response: array<string, mixed>|string|null, headers: array<string, string>, error: string|null}  $result
      */
     private function errorType(array $result): ?string
     {
-        $body = $result['response'];
+        $header = $result['headers']['x-amzn-errortype'] ?? null;
+        if (\is_string($header) && $header !== '') {
+            return \trim(\explode(':', $header)[0]);
+        }
 
+        $body = $result['response'];
         if (\is_array($body)) {
             $type = $body['__type'] ?? $body['code'] ?? null;
             if (\is_string($type)) {

--- a/tests/Messaging/Adapter/Email/ResendRoutingTest.php
+++ b/tests/Messaging/Adapter/Email/ResendRoutingTest.php
@@ -135,7 +135,7 @@ class ResendStub extends Resend
     /**
      * @param  array<string>  $headers
      * @param  array<string, mixed>|null  $body
-     * @return array{url: string, statusCode: int, response: array<string, mixed>|string|null, error: string|null}
+     * @return array{url: string, statusCode: int, response: array<string, mixed>|string|null, headers: array<string, string>, error: string|null}
      */
     protected function request(
         string $method,
@@ -158,6 +158,7 @@ class ResendStub extends Resend
             'url' => $url,
             'statusCode' => $stub['statusCode'],
             'response' => $stub['response'],
+            'headers' => [],
             'error' => null,
         ];
     }

--- a/tests/Messaging/Adapter/Email/SESRoutingTest.php
+++ b/tests/Messaging/Adapter/Email/SESRoutingTest.php
@@ -158,6 +158,83 @@ class SESRoutingTest extends TestCase
         $this->assertSame('success', $response['results'][0]['status']);
     }
 
+    public function testTopLevelMissingTemplateTriggersCreateAndRetry(): void
+    {
+        $stub = new SESStub('key', 'secret', 'us-east-1');
+
+        // The real SES v2 response for a missing DefaultContent template is a
+        // top-level 400 whose exception type lives only in the x-amzn-ErrorType
+        // response header, with a plain {"message": ...} body. The auto-create
+        // must trigger off that, not off a per-entry BulkEmailEntryResults
+        // status (which SES does not return for a missing default template).
+        $stub->stubResponses[] = [
+            'statusCode' => 400,
+            'headers' => ['x-amzn-errortype' => 'BadRequestException'],
+            'response' => ['message' => 'Template utopia-abc123 does not exist.'],
+        ];
+        $stub->stubResponses[] = ['statusCode' => 200, 'response' => []];
+        $stub->stubResponses[] = [
+            'statusCode' => 200,
+            'response' => ['BulkEmailEntryResults' => [['Status' => 'SUCCESS', 'MessageId' => 'x']]],
+        ];
+
+        $message = new Email(
+            to: [['email' => 'a@example.com']],
+            subject: 'Subject',
+            content: 'Body',
+            fromName: 'Sender',
+            fromEmail: 'from@example.com',
+        );
+
+        $response = $stub->send($message);
+
+        $this->assertCount(3, $stub->capturedRequests);
+        $this->assertStringEndsWith('/v2/email/outbound-bulk-emails', $stub->capturedRequests[0]['url']);
+        $this->assertStringEndsWith('/v2/email/templates', $stub->capturedRequests[1]['url']);
+        $this->assertStringEndsWith('/v2/email/outbound-bulk-emails', $stub->capturedRequests[2]['url']);
+
+        $this->assertSame(1, $response['deliveredTo']);
+        $this->assertSame('success', $response['results'][0]['status']);
+    }
+
+    public function testCreateTemplateToleratesAlreadyExists(): void
+    {
+        $stub = new SESStub('key', 'secret', 'us-east-1');
+
+        // Missing on the first send (top-level 400) ...
+        $stub->stubResponses[] = [
+            'statusCode' => 400,
+            'headers' => ['x-amzn-errortype' => 'BadRequestException'],
+            'response' => ['message' => 'Template utopia-abc123 does not exist.'],
+        ];
+        // ... but a concurrent sender created it first, so CreateEmailTemplate
+        // returns AlreadyExistsException (again, type in the header). That must
+        // be tolerated rather than surfaced as a failure.
+        $stub->stubResponses[] = [
+            'statusCode' => 400,
+            'headers' => ['x-amzn-errortype' => 'AlreadyExistsException'],
+            'response' => ['message' => 'Template utopia-abc123 already exists.'],
+        ];
+        $stub->stubResponses[] = [
+            'statusCode' => 200,
+            'response' => ['BulkEmailEntryResults' => [['Status' => 'SUCCESS']]],
+        ];
+
+        $message = new Email(
+            to: [['email' => 'a@example.com']],
+            subject: 'Subject',
+            content: 'Body',
+            fromName: 'Sender',
+            fromEmail: 'from@example.com',
+        );
+
+        $response = $stub->send($message);
+
+        $this->assertCount(3, $stub->capturedRequests);
+        $this->assertSame(1, $response['deliveredTo']);
+        $this->assertSame('success', $response['results'][0]['status']);
+    }
+
     public function testTextTemplateUsesTextContent(): void
     {
         $stub = new SESStub('key', 'secret', 'us-east-1');
@@ -573,14 +650,14 @@ class SESStub extends SES
     public array $capturedRequests = [];
 
     /**
-     * @var array<array{statusCode: int, response: array<string, mixed>|string|null}>
+     * @var array<array{statusCode: int, response: array<string, mixed>|string|null, headers?: array<string, string>}>
      */
     public array $stubResponses = [];
 
     /**
      * @param  array<string>  $headers
      * @param  array<string, mixed>|null  $body
-     * @return array{url: string, statusCode: int, response: array<string, mixed>|string|null, error: string|null}
+     * @return array{url: string, statusCode: int, response: array<string, mixed>|string|null, headers: array<string, string>, error: string|null}
      */
     protected function request(
         string $method,
@@ -603,6 +680,7 @@ class SESStub extends SES
             'url' => $url,
             'statusCode' => $stub['statusCode'],
             'response' => $stub['response'],
+            'headers' => $stub['headers'] ?? [],
             'error' => null,
         ];
     }


### PR DESCRIPTION
## Problem

Sending email through the SES adapter fails on the **first send of any new message content** with:

> Template utopia-&lt;hash&gt; does not exist.

even with a fully-permissioned IAM user (`ses:*`). Reported from a real Cloud project; the error reproduces 100% of the time for first-time content.

## Root cause

The no-attachment path is template-based ([`SES.php`](https://github.com/utopia-php/messaging/blob/fix-ses-template-detection/src/Utopia/Messaging/Adapter/Email/SES.php)): it sends via `SendBulkEmail` referencing a content-hashed template (`utopia-<hash>`). On the first send that template does not exist yet, so the adapter is designed to **detect the "template missing" error → `CreateEmailTemplate` → retry**.

That recovery never fired. SES API v2 uses the AWS REST-JSON protocol, which returns the exception type (`BadRequestException`) in the **`x-amzn-ErrorType` response header** — the JSON body is only `{"message":"Template ... does not exist."}`. But the base `Adapter::request()` used `CURLOPT_RETURNTRANSFER` only and **discarded every response header**. So:

- `errorType()` read the body, found no `__type`, and returned `null`
- `isTemplateMissing()` returned `false`
- the template was never created, and the raw error fell through to every recipient

Verified against the live endpoint — an unsigned SES request returns the type in the header (`x-amzn-errortype: MissingAuthenticationTokenException`), confirming the body never carries it.

### Why CI stayed green

The routing test mocked a missing template as a `200` with a per-entry `TEMPLATE_NOT_FOUND` status — a shape SES **never returns** for a missing default template (that case is always a top-level `400`). The test and the code shared the same wrong assumption, so they agreed with each other and disagreed with SES.

## Fix

1. **`Adapter::request()`** — capture response headers via `CURLOPT_HEADERFUNCTION` (lowercased keys) and expose them under a new additive `headers` key. No other adapter is affected.
2. **`SES::errorType()`** — read the type from `x-amzn-ErrorType` first, keeping the body `__type`/`code` as a fallback for AWS JSON-protocol responses.
3. **`SES::isTemplateMissing()`** — require the message to signal non-existence ("does not exist" / "not found") so an unrelated `BadRequestException` mentioning a template is not misclassified.

## Tests

- Two new regression tests reproduce the **real** SES shape (top-level `400` + `x-amzn-ErrorType` header): the create-and-retry recovery and the concurrent `AlreadyExistsException` race. Both **fail without the fix** (1 request, recipient failure) and **pass with it** (3 requests, delivered).
- Routing stubs updated to return the new `headers` key.

## Verification

- New regression tests: fail → pass as required
- Network-free routing/signing suites: 30 passing
- Full suite vs. baseline: **zero** new failures (pre-existing reds are live-integration tests needing credentials/`request-catcher`)
- `composer lint` (Pint, PSR-12): pass
- `composer analyse` (PHPStan level 6): `[OK] No errors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)