### PR TITLE
feat: add AfricasTalking SMS adapter

### DIFF
--- a/src/Utopia/Messaging/Adapter/SMS/AfricasTalking.php
+++ b/src/Utopia/Messaging/Adapter/SMS/AfricasTalking.php
@@ -10,7 +10,7 @@ class AfricasTalking extends SMSAdapter
 {
     protected const NAME = 'AfricasTalking';
 
-    private const API_URL = 'https://api.africasTalking.com/sms/1/action';
+    private const API_URL = 'https://api.africasTalking.com/version1/messaging';
 
     public function __construct(
         private string $username,
@@ -34,10 +34,7 @@ class AfricasTalking extends SMSAdapter
     {
         $response = new Response($this->getType());
 
-        $recipients = \array_map(
-            fn ($to) => \ltrim($to, '+'),
-            $message->getTo()
-        );
+        $recipients = $message->getTo();
 
         $from = $this->from ?? $message->getFrom();
 

--- a/src/Utopia/Messaging/Adapter/SMS/AfricasTalking.php
+++ b/src/Utopia/Messaging/Adapter/SMS/AfricasTalking.php
@@ -17,6 +17,7 @@ class AfricasTalking extends SMSAdapter
         private string $apiKey,
         private ?string $from = null
     ) {
+        parent::__construct();
     }
 
     public function getName(): string
@@ -62,9 +63,13 @@ class AfricasTalking extends SMSAdapter
             } else {
                 $errorMessage = 'Unknown error';
                 if (isset($result['response']['errorMessage'])) {
-                    $errorMessage = $result['response']['errorMessage'];
+                    $errorMessage = \is_string($result['response']['errorMessage'])
+                        ? $result['response']['errorMessage']
+                        : \json_encode($result['response']['errorMessage']);
                 } elseif (isset($result['response']['message'])) {
-                    $errorMessage = $result['response']['message'];
+                    $errorMessage = \is_string($result['response']['message'])
+                        ? $result['response']['message']
+                        : \json_encode($result['response']['message']);
                 }
                 $response->addResult($recipient, $errorMessage);
             }

--- a/src/Utopia/Messaging/Adapter/SMS/AfricasTalking.php
+++ b/src/Utopia/Messaging/Adapter/SMS/AfricasTalking.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Utopia\Messaging\Adapter\SMS;
+
+use Utopia\Messaging\Adapter\SMS as SMSAdapter;
+use Utopia\Messaging\Messages\SMS as SMSMessage;
+use Utopia\Messaging\Response;
+
+class AfricasTalking extends SMSAdapter
+{
+    protected const NAME = 'AfricasTalking';
+
+    private const API_URL = 'https://api.africasTalking.com/sms/1/action';
+
+    public function __construct(
+        private string $username,
+        private string $apiKey,
+        private ?string $from = null
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return static::NAME;
+    }
+
+    public function getMaxMessagesPerRequest(): int
+    {
+        return 100;
+    }
+
+    protected function process(SMSMessage $message): array
+    {
+        $response = new Response($this->getType());
+
+        $recipients = \array_map(
+            fn ($to) => \ltrim($to, '+'),
+            $message->getTo()
+        );
+
+        $from = $this->from ?? $message->getFrom();
+
+        foreach ($recipients as $recipient) {
+            $result = $this->request(
+                method: 'POST',
+                url: self::API_URL,
+                headers: [
+                    'Content-Type: application/x-www-form-urlencoded',
+                    'apiKey: ' . $this->apiKey,
+                ],
+                body: [
+                    'username' => $this->username,
+                    'to' => $recipient,
+                    'message' => $message->getContent(),
+                    'from' => $from,
+                ]
+            );
+
+            if ($result['statusCode'] === 201) {
+                $response->incrementDeliveredTo();
+                $response->addResult($recipient);
+            } else {
+                $errorMessage = 'Unknown error';
+                if (isset($result['response']['errorMessage'])) {
+                    $errorMessage = $result['response']['errorMessage'];
+                } elseif (isset($result['response']['message'])) {
+                    $errorMessage = $result['response']['message'];
+                }
+                $response->addResult($recipient, $errorMessage);
+            }
+        }
+
+        return $response->toArray();
+    }
+}

--- a/tests/Messaging/Adapter/SMS/AfricasTalkingTest.php
+++ b/tests/Messaging/Adapter/SMS/AfricasTalkingTest.php
@@ -28,9 +28,7 @@ class AfricasTalkingTest extends Base
 
         $response = $sender->send($message);
 
-        $result = \json_decode($response, true);
-
-        $this->assertResponse($result);
+        $this->assertResponse($response);
     }
 
     public function testSendSMSWithFrom(): void
@@ -53,8 +51,6 @@ class AfricasTalkingTest extends Base
 
         $response = $sender->send($message);
 
-        $result = \json_decode($response, true);
-
-        $this->assertResponse($result);
+        $this->assertResponse($response);
     }
 }

--- a/tests/Messaging/Adapter/SMS/AfricasTalkingTest.php
+++ b/tests/Messaging/Adapter/SMS/AfricasTalkingTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Utopia\Tests\Adapter\SMS;
+
+use Utopia\Messaging\Adapter\SMS\AfricasTalking;
+use Utopia\Messaging\Messages\SMS;
+use Utopia\Tests\Adapter\Base;
+
+class AfricasTalkingTest extends Base
+{
+    public function testSendSMS(): void
+    {
+        $username = \getenv('AFRICAS_TALKING_USERNAME');
+        $apiKey = \getenv('AFRICAS_TALKING_API_KEY');
+        $to = \getenv('AFRICAS_TALKING_TO');
+
+        if (empty($username) || empty($apiKey) || empty($to)) {
+            $this->markTestSkipped('AfricasTalking credentials are not available.');
+        }
+
+        $sender = new AfricasTalking($username, $apiKey);
+
+        $message = new SMS(
+            to: [$to],
+            content: 'Test Content',
+            from: \getenv('AFRICAS_TALKING_FROM') ?: null
+        );
+
+        $response = $sender->send($message);
+
+        $result = \json_decode($response, true);
+
+        $this->assertResponse($result);
+    }
+
+    public function testSendSMSWithFrom(): void
+    {
+        $username = \getenv('AFRICAS_TALKING_USERNAME');
+        $apiKey = \getenv('AFRICAS_TALKING_API_KEY');
+        $to = \getenv('AFRICAS_TALKING_TO');
+        $from = \getenv('AFRICAS_TALKING_FROM');
+
+        if (empty($username) || empty($apiKey) || empty($to)) {
+            $this->markTestSkipped('AfricasTalking credentials are not available.');
+        }
+
+        $sender = new AfricasTalking($username, $apiKey, $from ?: 'AFRICAST');
+
+        $message = new SMS(
+            to: [$to],
+            content: 'Test Content with custom from'
+        );
+
+        $response = $sender->send($message);
+
+        $result = \json_decode($response, true);
+
+        $this->assertResponse($result);
+    }
+}


### PR DESCRIPTION
- New SMS adapter for AfricasTalking API
- Supports sending SMS messages with optional 'from' field
- Handles up to 100 messages per request
- Proper error handling for API responses
- Includes integration tests
