### PR TITLE
Add MSG91 metadata tracking

### DIFF
--- a/src/Utopia/Messaging/Adapter/SMS/GEOSMS.php
+++ b/src/Utopia/Messaging/Adapter/SMS/GEOSMS.php
@@ -82,29 +82,41 @@ class GEOSMS extends SMSAdapter
     {
         $results = [];
         $recipients = $message->getTo();
+        $batches = [];
 
         do {
             [$nextRecipients, $nextAdapter] = $this->getNextRecipientsAndAdapter($recipients);
+            $batches[] = [
+                'recipients' => $nextRecipients,
+                'adapter' => $nextAdapter,
+            ];
 
+            $recipients = \array_diff($recipients, $nextRecipients);
+        } while (count($recipients) > 0);
+
+        $metadata = $message->getMetadata();
+        if (\count($batches) > 1 && $metadata !== null) {
+            unset($metadata['CRQID'], $metadata['UUID']);
+        }
+
+        foreach ($batches as $batch) {
             try {
-                $results[$nextAdapter->getName()] = $nextAdapter->send(
+                $results[$batch['adapter']->getName()] = $batch['adapter']->send(
                     (new SMS(
-                        to: $nextRecipients,
+                        to: $batch['recipients'],
                         content: $message->getContent(),
                         from: $message->getFrom(),
                         attachments: $message->getAttachments(),
-                        metadata: $message->getMetadata()
+                        metadata: $metadata
                     ))->setOrigin($message->getOrigin())
                 );
             } catch (\Exception $e) {
-                $results[$nextAdapter->getName()] = [
+                $results[$batch['adapter']->getName()] = [
                     'type' => 'error',
                     'message' => $e->getMessage(),
                 ];
             }
-
-            $recipients = \array_diff($recipients, $nextRecipients);
-        } while (count($recipients) > 0);
+        }
 
         return $results;
     }

--- a/src/Utopia/Messaging/Adapter/SMS/GEOSMS.php
+++ b/src/Utopia/Messaging/Adapter/SMS/GEOSMS.php
@@ -4,6 +4,7 @@ namespace Utopia\Messaging\Adapter\SMS;
 
 use Utopia\Messaging\Adapter\SMS as SMSAdapter;
 use Utopia\Messaging\Adapter\SMS\GEOSMS\CallingCode;
+use Utopia\Messaging\Adapter\SMS\Msg91\MetadataParameter;
 use Utopia\Messaging\Messages\SMS;
 use Utopia\Telemetry\Adapter as Telemetry;
 use Utopia\Telemetry\Adapter\None as NoTelemetry;
@@ -95,11 +96,22 @@ class GEOSMS extends SMSAdapter
         } while (count($recipients) > 0);
 
         foreach ($batches as $index => $batch) {
+            /** @var array<string, mixed>|null $metadata */
             $metadata = $message->getMetadata();
             if (\count($batches) > 1 && $metadata !== null) {
-                foreach (['CRQID', 'UUID'] as $key) {
-                    if (!isset($metadata[$key])) {
+                foreach ([MetadataParameter::CRQID, MetadataParameter::UUID] as $parameter) {
+                    $key = $parameter->value;
+
+                    if (!\array_key_exists($key, $metadata)) {
                         continue;
+                    }
+
+                    if (!\is_string($metadata[$key])) {
+                        throw new \InvalidArgumentException("Msg91 {$key} metadata must be a string.");
+                    }
+
+                    if (\strlen($metadata[$key]) > 80 || !\preg_match('/^[A-Za-z0-9_.-]+$/', $metadata[$key])) {
+                        throw new \InvalidArgumentException("Msg91 {$key} metadata must be 80 characters or less and contain only alphanumeric characters, underscores, dots, or hyphens.");
                     }
 
                     $suffix = '-'.($index + 1);

--- a/src/Utopia/Messaging/Adapter/SMS/GEOSMS.php
+++ b/src/Utopia/Messaging/Adapter/SMS/GEOSMS.php
@@ -94,12 +94,19 @@ class GEOSMS extends SMSAdapter
             $recipients = \array_diff($recipients, $nextRecipients);
         } while (count($recipients) > 0);
 
-        $metadata = $message->getMetadata();
-        if (\count($batches) > 1 && $metadata !== null) {
-            unset($metadata['CRQID'], $metadata['UUID']);
-        }
+        foreach ($batches as $index => $batch) {
+            $metadata = $message->getMetadata();
+            if (\count($batches) > 1 && $metadata !== null) {
+                foreach (['CRQID', 'UUID'] as $key) {
+                    if (!isset($metadata[$key])) {
+                        continue;
+                    }
 
-        foreach ($batches as $batch) {
+                    $suffix = '-'.($index + 1);
+                    $metadata[$key] = \substr($metadata[$key], 0, 80 - \strlen($suffix)).$suffix;
+                }
+            }
+
             try {
                 $results[$batch['adapter']->getName()] = $batch['adapter']->send(
                     (new SMS(

--- a/src/Utopia/Messaging/Adapter/SMS/GEOSMS.php
+++ b/src/Utopia/Messaging/Adapter/SMS/GEOSMS.php
@@ -92,7 +92,8 @@ class GEOSMS extends SMSAdapter
                         to: $nextRecipients,
                         content: $message->getContent(),
                         from: $message->getFrom(),
-                        attachments: $message->getAttachments()
+                        attachments: $message->getAttachments(),
+                        metadata: $message->getMetadata()
                     ))->setOrigin($message->getOrigin())
                 );
             } catch (\Exception $e) {

--- a/src/Utopia/Messaging/Adapter/SMS/Msg91.php
+++ b/src/Utopia/Messaging/Adapter/SMS/Msg91.php
@@ -2,6 +2,7 @@
 
 namespace Utopia\Messaging\Adapter\SMS;
 
+use Utopia\Messaging\Adapter\SMS\Msg91\MetadataParameter;
 use Utopia\Messaging\Adapter\SMS as SMSAdapter;
 use Utopia\Messaging\Messages\SMS as SMSMessage;
 use Utopia\Messaging\Response;
@@ -51,6 +52,31 @@ class Msg91 extends SMSAdapter
             ];
         }
 
+        $body = [
+            'sender' => $this->senderId,
+            'template_id' => $this->templateId,
+            'recipients' => $recipients,
+        ];
+
+        $metadata = $message->getMetadata() ?? [];
+        $metadata = \array_intersect_key($metadata, \array_flip(\array_column(MetadataParameter::cases(), 'value')));
+
+        foreach ([MetadataParameter::CRQID, MetadataParameter::UUID] as $parameter) {
+            $key = $parameter->value;
+
+            if (!isset($metadata[$key])) {
+                continue;
+            }
+
+            if (\strlen($metadata[$key]) > 80 || !\preg_match('/^[A-Za-z0-9_.-]+$/', $metadata[$key])) {
+                throw new \InvalidArgumentException("Msg91 {$key} metadata must be 80 characters or less and contain only alphanumeric characters, underscores, dots, or hyphens.");
+            }
+        }
+
+        foreach ($metadata as $key => $value) {
+            $body[$key] = $value;
+        }
+
         $response = new Response($this->getType());
         $result = $this->request(
             method: 'POST',
@@ -59,11 +85,7 @@ class Msg91 extends SMSAdapter
                 'Content-Type: application/json',
                 'Authkey: '. $this->authKey,
             ],
-            body: [
-                'sender' => $this->senderId,
-                'template_id' => $this->templateId,
-                'recipients' => $recipients,
-            ],
+            body: $body,
         );
 
         if ($result['statusCode'] === 200) {

--- a/src/Utopia/Messaging/Adapter/SMS/Msg91.php
+++ b/src/Utopia/Messaging/Adapter/SMS/Msg91.php
@@ -64,18 +64,13 @@ class Msg91 extends SMSAdapter
             }
         }
 
-        $recipientMetadata = \array_intersect_key($metadata, \array_flip([
-            MetadataParameter::CRQID->value,
-            MetadataParameter::UUID->value,
-        ]));
-
         $recipients = [];
         foreach ($message->getTo() as $recipient) {
             $recipients[] = [
                 'mobiles' => \ltrim($recipient, '+'),
                 'content' => $message->getContent(),
                 'otp' => $message->getContent(),
-            ] + $recipientMetadata;
+            ];
         }
 
         $body = [

--- a/src/Utopia/Messaging/Adapter/SMS/Msg91.php
+++ b/src/Utopia/Messaging/Adapter/SMS/Msg91.php
@@ -43,28 +43,19 @@ class Msg91 extends SMSAdapter
      */
     protected function process(SMSMessage $message): array
     {
-        $recipients = [];
-        foreach ($message->getTo() as $recipient) {
-            $recipients[] = [
-                'mobiles' => \ltrim($recipient, '+'),
-                'content' => $message->getContent(),
-                'otp' => $message->getContent(),
-            ];
-        }
-
-        $body = [
-            'sender' => $this->senderId,
-            'template_id' => $this->templateId,
-            'recipients' => $recipients,
-        ];
-
         $metadata = $message->getMetadata() ?? [];
         $metadata = \array_intersect_key($metadata, \array_flip(\array_column(MetadataParameter::cases(), 'value')));
+
+        foreach ($metadata as $key => $value) {
+            if (!\is_string($value)) {
+                throw new \InvalidArgumentException("Msg91 {$key} metadata must be a string.");
+            }
+        }
 
         foreach ([MetadataParameter::CRQID, MetadataParameter::UUID] as $parameter) {
             $key = $parameter->value;
 
-            if (!isset($metadata[$key])) {
+            if (!\array_key_exists($key, $metadata)) {
                 continue;
             }
 
@@ -72,6 +63,26 @@ class Msg91 extends SMSAdapter
                 throw new \InvalidArgumentException("Msg91 {$key} metadata must be 80 characters or less and contain only alphanumeric characters, underscores, dots, or hyphens.");
             }
         }
+
+        $recipientMetadata = \array_intersect_key($metadata, \array_flip([
+            MetadataParameter::CRQID->value,
+            MetadataParameter::UUID->value,
+        ]));
+
+        $recipients = [];
+        foreach ($message->getTo() as $recipient) {
+            $recipients[] = [
+                'mobiles' => \ltrim($recipient, '+'),
+                'content' => $message->getContent(),
+                'otp' => $message->getContent(),
+            ] + $recipientMetadata;
+        }
+
+        $body = [
+            'sender' => $this->senderId,
+            'template_id' => $this->templateId,
+            'recipients' => $recipients,
+        ];
 
         foreach ($metadata as $key => $value) {
             $body[$key] = $value;

--- a/src/Utopia/Messaging/Adapter/SMS/Msg91/MetadataParameter.php
+++ b/src/Utopia/Messaging/Adapter/SMS/Msg91/MetadataParameter.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Utopia\Messaging\Adapter\SMS\Msg91;
+
+enum MetadataParameter: string
+{
+    /**
+     * Returned in Webhook v2 callbacks to correlate MSG91 responses with the original request.
+     */
+    case CLIENT_ID = 'clientId';
+
+    /**
+     * Request-level tracking ID returned in delivery reports and webhook callbacks.
+     */
+    case CRQID = 'CRQID';
+
+    /**
+     * Alternative request-level tracking ID returned in delivery reports and webhook callbacks.
+     */
+    case UUID = 'UUID';
+}

--- a/src/Utopia/Messaging/Messages/SMS.php
+++ b/src/Utopia/Messaging/Messages/SMS.php
@@ -11,12 +11,14 @@ class SMS implements Message
     /**
      * @param  array<string>  $to
      * @param  array<string>|null  $attachments
+     * @param  array<string, string>|null  $metadata
      */
     public function __construct(
         private array $to,
         private string $content,
         private ?string $from = null,
         private ?array $attachments = null,
+        private ?array $metadata = null,
     ) {
     }
 
@@ -44,6 +46,24 @@ class SMS implements Message
     public function getAttachments(): ?array
     {
         return $this->attachments;
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    public function getMetadata(): ?array
+    {
+        return $this->metadata;
+    }
+
+    /**
+     * @param  array<string, string>|null  $metadata
+     */
+    public function setMetadata(?array $metadata): self
+    {
+        $this->metadata = $metadata;
+
+        return $this;
     }
 
     public function setOrigin(?string $origin): self

--- a/tests/Messaging/Adapter/SMS/GEOSMSTest.php
+++ b/tests/Messaging/Adapter/SMS/GEOSMSTest.php
@@ -143,8 +143,16 @@ class GEOSMSTest extends Base
         $this->assertEquals(1, count($result));
         $this->assertEquals('success', $result['default']['results'][0]['status']);
 
-        $expectedMetadata = [
+        $defaultMetadata = [
             'clientId' => 'client-123',
+            'CRQID' => 'request_123-2',
+            'UUID' => 'uuid.123-2',
+        ];
+
+        $localMetadata = [
+            'clientId' => 'client-123',
+            'CRQID' => 'request_123-1',
+            'UUID' => 'uuid.123-1',
         ];
 
         $defaultAdapterMock = $this->createMock(SMSAdapter::class);
@@ -152,8 +160,8 @@ class GEOSMSTest extends Base
         $defaultAdapterMock
             ->expects($this->once())
             ->method('send')
-            ->with($this->callback(function (SMS $message) use ($expectedMetadata): bool {
-                return $message->getMetadata() === $expectedMetadata;
+            ->with($this->callback(function (SMS $message) use ($defaultMetadata): bool {
+                return $message->getMetadata() === $defaultMetadata;
             }))
             ->willReturn(['results' => [['status' => 'success']]]);
 
@@ -162,8 +170,8 @@ class GEOSMSTest extends Base
         $localAdapterMock
             ->expects($this->once())
             ->method('send')
-            ->with($this->callback(function (SMS $message) use ($expectedMetadata): bool {
-                return $message->getMetadata() === $expectedMetadata;
+            ->with($this->callback(function (SMS $message) use ($localMetadata): bool {
+                return $message->getMetadata() === $localMetadata;
             }))
             ->willReturn(['results' => [['status' => 'success']]]);
 

--- a/tests/Messaging/Adapter/SMS/GEOSMSTest.php
+++ b/tests/Messaging/Adapter/SMS/GEOSMSTest.php
@@ -189,5 +189,38 @@ class GEOSMSTest extends Base
         $this->assertEquals(2, count($result));
         $this->assertEquals('success', $result['local']['results'][0]['status']);
         $this->assertEquals('success', $result['default']['results'][0]['status']);
+
+        /** @var array<string, string> $invalidMetadata */
+        $invalidMetadata = [
+            'CRQID' => [],
+        ];
+
+        $message = new SMS(
+            to: ['+911234567890', '+11234567890'],
+            content: 'Test Content',
+            metadata: $invalidMetadata
+        );
+
+        try {
+            $adapter->send($message);
+            $this->fail('Expected invalid GEOSMS metadata to throw.');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertStringContainsString('Msg91 CRQID metadata must be a string', $e->getMessage());
+        }
+
+        $message = new SMS(
+            to: ['+911234567890', '+11234567890'],
+            content: 'Test Content',
+            metadata: [
+                'CRQID' => '',
+            ]
+        );
+
+        try {
+            $adapter->send($message);
+            $this->fail('Expected empty GEOSMS metadata to throw.');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertStringContainsString('Msg91 CRQID metadata must be 80 characters or less', $e->getMessage());
+        }
     }
 }

--- a/tests/Messaging/Adapter/SMS/GEOSMSTest.php
+++ b/tests/Messaging/Adapter/SMS/GEOSMSTest.php
@@ -143,4 +143,52 @@ class GEOSMSTest extends Base
         $this->assertEquals(1, count($result));
         $this->assertEquals('success', $result['default']['results'][0]['status']);
     }
+
+    public function testSendSMSRemovesRequestTrackingMetadataWhenSplit(): void
+    {
+        $metadata = [
+            'clientId' => 'client-123',
+            'CRQID' => 'request_123',
+            'UUID' => 'uuid.123',
+        ];
+
+        $expectedMetadata = [
+            'clientId' => 'client-123',
+        ];
+
+        $defaultAdapterMock = $this->createMock(SMSAdapter::class);
+        $defaultAdapterMock->method('getName')->willReturn('default');
+        $defaultAdapterMock
+            ->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function (SMS $message) use ($expectedMetadata): bool {
+                return $message->getMetadata() === $expectedMetadata;
+            }))
+            ->willReturn(['results' => [['status' => 'success']]]);
+
+        $localAdapterMock = $this->createMock(SMSAdapter::class);
+        $localAdapterMock->method('getName')->willReturn('local');
+        $localAdapterMock
+            ->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function (SMS $message) use ($expectedMetadata): bool {
+                return $message->getMetadata() === $expectedMetadata;
+            }))
+            ->willReturn(['results' => [['status' => 'success']]]);
+
+        $adapter = new GEOSMS($defaultAdapterMock);
+        $adapter->setLocal(CallingCode::INDIA, $localAdapterMock);
+
+        $message = new SMS(
+            to: ['+911234567890', '+11234567890'],
+            content: 'Test Content',
+            metadata: $metadata
+        );
+
+        $result = $adapter->send($message);
+
+        $this->assertEquals(2, count($result));
+        $this->assertEquals('success', $result['local']['results'][0]['status']);
+        $this->assertEquals('success', $result['default']['results'][0]['status']);
+    }
 }

--- a/tests/Messaging/Adapter/SMS/GEOSMSTest.php
+++ b/tests/Messaging/Adapter/SMS/GEOSMSTest.php
@@ -112,7 +112,7 @@ class GEOSMSTest extends Base
         $this->assertEquals('success', $result['local']['results'][0]['status']);
     }
 
-    public function testSendSMSForwardsMetadata(): void
+    public function testSendSMSHandlesMetadata(): void
     {
         $metadata = [
             'clientId' => 'client-123',
@@ -142,15 +142,6 @@ class GEOSMSTest extends Base
 
         $this->assertEquals(1, count($result));
         $this->assertEquals('success', $result['default']['results'][0]['status']);
-    }
-
-    public function testSendSMSRemovesRequestTrackingMetadataWhenSplit(): void
-    {
-        $metadata = [
-            'clientId' => 'client-123',
-            'CRQID' => 'request_123',
-            'UUID' => 'uuid.123',
-        ];
 
         $expectedMetadata = [
             'clientId' => 'client-123',

--- a/tests/Messaging/Adapter/SMS/GEOSMSTest.php
+++ b/tests/Messaging/Adapter/SMS/GEOSMSTest.php
@@ -111,4 +111,36 @@ class GEOSMSTest extends Base
         $this->assertEquals(1, count($result));
         $this->assertEquals('success', $result['local']['results'][0]['status']);
     }
+
+    public function testSendSMSForwardsMetadata(): void
+    {
+        $metadata = [
+            'clientId' => 'client-123',
+            'CRQID' => 'request_123',
+            'UUID' => 'uuid.123',
+        ];
+
+        $defaultAdapterMock = $this->createMock(SMSAdapter::class);
+        $defaultAdapterMock->method('getName')->willReturn('default');
+        $defaultAdapterMock
+            ->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function (SMS $message) use ($metadata): bool {
+                return $message->getMetadata() === $metadata;
+            }))
+            ->willReturn(['results' => [['status' => 'success']]]);
+
+        $adapter = new GEOSMS($defaultAdapterMock);
+
+        $message = new SMS(
+            to: ['+11234567890'],
+            content: 'Test Content',
+            metadata: $metadata
+        );
+
+        $result = $adapter->send($message);
+
+        $this->assertEquals(1, count($result));
+        $this->assertEquals('success', $result['default']['results'][0]['status']);
+    }
 }

--- a/tests/Messaging/Adapter/SMS/Msg91Test.php
+++ b/tests/Messaging/Adapter/SMS/Msg91Test.php
@@ -47,10 +47,10 @@ class Msg91Test extends Base
         $this->assertEquals('client-123', $sender->body['clientId']);
         $this->assertEquals('request_123', $sender->body['CRQID']);
         $this->assertEquals('uuid.123', $sender->body['UUID']);
-        $this->assertEquals('request_123', $sender->body['recipients'][0]['CRQID']);
-        $this->assertEquals('uuid.123', $sender->body['recipients'][0]['UUID']);
-        $this->assertEquals('request_123', $sender->body['recipients'][1]['CRQID']);
-        $this->assertEquals('uuid.123', $sender->body['recipients'][1]['UUID']);
+        $this->assertArrayNotHasKey('CRQID', $sender->body['recipients'][0]);
+        $this->assertArrayNotHasKey('UUID', $sender->body['recipients'][0]);
+        $this->assertArrayNotHasKey('CRQID', $sender->body['recipients'][1]);
+        $this->assertArrayNotHasKey('UUID', $sender->body['recipients'][1]);
         $this->assertArrayNotHasKey('ignored', $sender->body);
 
         $sender = new Msg91TestAdapter('sender', 'auth', 'template');

--- a/tests/Messaging/Adapter/SMS/Msg91Test.php
+++ b/tests/Messaging/Adapter/SMS/Msg91Test.php
@@ -27,7 +27,7 @@ class Msg91Test extends Base
         $sender = new Msg91TestAdapter('sender', 'auth', 'template');
 
         $message = new SMS(
-            to: ['+911234567890'],
+            to: ['+911234567890', '+911234567891'],
             content: 'Test Content',
             metadata: [
                 'clientId' => 'client-123',
@@ -39,10 +39,18 @@ class Msg91Test extends Base
 
         $response = $sender->send($message);
 
-        $this->assertResponse($response);
+        $this->assertEquals(2, $response['deliveredTo'], \var_export($response, true));
+        $this->assertEquals('', $response['results'][0]['error'], \var_export($response, true));
+        $this->assertEquals('success', $response['results'][0]['status'], \var_export($response, true));
+        $this->assertEquals('', $response['results'][1]['error'], \var_export($response, true));
+        $this->assertEquals('success', $response['results'][1]['status'], \var_export($response, true));
         $this->assertEquals('client-123', $sender->body['clientId']);
         $this->assertEquals('request_123', $sender->body['CRQID']);
         $this->assertEquals('uuid.123', $sender->body['UUID']);
+        $this->assertEquals('request_123', $sender->body['recipients'][0]['CRQID']);
+        $this->assertEquals('uuid.123', $sender->body['recipients'][0]['UUID']);
+        $this->assertEquals('request_123', $sender->body['recipients'][1]['CRQID']);
+        $this->assertEquals('uuid.123', $sender->body['recipients'][1]['UUID']);
         $this->assertArrayNotHasKey('ignored', $sender->body);
     }
 
@@ -60,6 +68,27 @@ class Msg91Test extends Base
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Msg91 CRQID metadata must be 80 characters or less');
+
+        $sender->send($message);
+    }
+
+    public function testSendSMSWithNullMetadata(): void
+    {
+        $sender = new Msg91TestAdapter('sender', 'auth', 'template');
+
+        /** @var array<string, string> $metadata */
+        $metadata = [
+            'CRQID' => null,
+        ];
+
+        $message = new SMS(
+            to: ['+911234567890'],
+            content: 'Test Content',
+            metadata: $metadata,
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Msg91 CRQID metadata must be a string');
 
         $sender->send($message);
     }

--- a/tests/Messaging/Adapter/SMS/Msg91Test.php
+++ b/tests/Messaging/Adapter/SMS/Msg91Test.php
@@ -21,4 +21,84 @@ class Msg91Test extends Base
 
         $this->assertResponse($response);
     }
+
+    public function testSendSMSWithMetadata(): void
+    {
+        $sender = new Msg91TestAdapter('sender', 'auth', 'template');
+
+        $message = new SMS(
+            to: ['+911234567890'],
+            content: 'Test Content',
+            metadata: [
+                'clientId' => 'client-123',
+                'CRQID' => 'request_123',
+                'UUID' => 'uuid.123',
+                'ignored' => 'value',
+            ],
+        );
+
+        $response = $sender->send($message);
+
+        $this->assertResponse($response);
+        $this->assertEquals('client-123', $sender->body['clientId']);
+        $this->assertEquals('request_123', $sender->body['CRQID']);
+        $this->assertEquals('uuid.123', $sender->body['UUID']);
+        $this->assertArrayNotHasKey('ignored', $sender->body);
+    }
+
+    public function testSendSMSWithInvalidMetadata(): void
+    {
+        $sender = new Msg91TestAdapter('sender', 'auth', 'template');
+
+        $message = new SMS(
+            to: ['+911234567890'],
+            content: 'Test Content',
+            metadata: [
+                'CRQID' => 'invalid value',
+            ],
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Msg91 CRQID metadata must be 80 characters or less');
+
+        $sender->send($message);
+    }
+}
+
+class Msg91TestAdapter extends Msg91
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public array $body = [];
+
+    /**
+     * @param  array<string>  $headers
+     * @param  array<string, mixed>|null  $body
+     * @return array{
+     *     url: string,
+     *     statusCode: int,
+     *     response: array<string, mixed>|string|null,
+     *     headers: array<string, string>,
+     *     error: string|null
+     * }
+     */
+    protected function request(
+        string $method,
+        string $url,
+        array $headers = [],
+        ?array $body = null,
+        int $timeout = 30,
+        int $connectTimeout = 10
+    ): array {
+        $this->body = $body ?? [];
+
+        return [
+            'url' => $url,
+            'statusCode' => 200,
+            'response' => [],
+            'headers' => [],
+            'error' => null,
+        ];
+    }
 }

--- a/tests/Messaging/Adapter/SMS/Msg91Test.php
+++ b/tests/Messaging/Adapter/SMS/Msg91Test.php
@@ -22,7 +22,7 @@ class Msg91Test extends Base
         $this->assertResponse($response);
     }
 
-    public function testSendSMSWithMetadata(): void
+    public function testSendSMSHandlesMetadata(): void
     {
         $sender = new Msg91TestAdapter('sender', 'auth', 'template');
 
@@ -52,10 +52,7 @@ class Msg91Test extends Base
         $this->assertEquals('request_123', $sender->body['recipients'][1]['CRQID']);
         $this->assertEquals('uuid.123', $sender->body['recipients'][1]['UUID']);
         $this->assertArrayNotHasKey('ignored', $sender->body);
-    }
 
-    public function testSendSMSWithInvalidMetadata(): void
-    {
         $sender = new Msg91TestAdapter('sender', 'auth', 'template');
 
         $message = new SMS(
@@ -66,15 +63,12 @@ class Msg91Test extends Base
             ],
         );
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Msg91 CRQID metadata must be 80 characters or less');
-
-        $sender->send($message);
-    }
-
-    public function testSendSMSWithNullMetadata(): void
-    {
-        $sender = new Msg91TestAdapter('sender', 'auth', 'template');
+        try {
+            $sender->send($message);
+            $this->fail('Expected invalid MSG91 metadata to throw.');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertStringContainsString('Msg91 CRQID metadata must be 80 characters or less', $e->getMessage());
+        }
 
         /** @var array<string, string> $metadata */
         $metadata = [
@@ -87,10 +81,12 @@ class Msg91Test extends Base
             metadata: $metadata,
         );
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Msg91 CRQID metadata must be a string');
-
-        $sender->send($message);
+        try {
+            $sender->send($message);
+            $this->fail('Expected null MSG91 metadata to throw.');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertStringContainsString('Msg91 CRQID metadata must be a string', $e->getMessage());
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds support for MSG91 request tracking metadata on SMS messages.

This introduces a provider-specific `MetadataParameter` enum for MSG91-supported metadata keys, stores optional metadata on SMS messages, and attaches supported metadata fields to MSG91 flow requests. `CRQID` and `UUID` are validated against MSG91 documented constraints before sending and are kept as request-level MSG91 fields.

GEOSMS now preserves SMS metadata when routing messages to a single downstream send. When GEOSMS fans out one message into multiple adapter sends, it derives unique request-level `CRQID` and `UUID` values per child request to avoid duplicated provider tracking identifiers while preserving correlation.

## Test Plan

- `./vendor/bin/phpunit tests/Messaging/Adapter/SMS/Msg91Test.php tests/Messaging/Adapter/SMS/GEOSMSTest.php`
- `./vendor/bin/pint --preset psr12 --test src/Utopia/Messaging/Adapter/SMS/Msg91.php src/Utopia/Messaging/Adapter/SMS/GEOSMS.php src/Utopia/Messaging/Adapter/SMS/Msg91/MetadataParameter.php src/Utopia/Messaging/Messages/SMS.php tests/Messaging/Adapter/SMS/Msg91Test.php tests/Messaging/Adapter/SMS/GEOSMSTest.php`
- `./vendor/bin/phpstan analyse --memory-limit=2G --level=6 src/Utopia/Messaging/Messages/SMS.php src/Utopia/Messaging/Adapter/SMS/Msg91.php src/Utopia/Messaging/Adapter/SMS/GEOSMS.php src/Utopia/Messaging/Adapter/SMS/Msg91/MetadataParameter.php tests/Messaging/Adapter/SMS/Msg91Test.php tests/Messaging/Adapter/SMS/GEOSMSTest.php`

## Related PRs and Issues

#XXXX

### Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md)?

Yes.
