### PR TITLE
(feat): surface transport error details in FCM push results

### DIFF
--- a/src/Utopia/Messaging/Adapter.php
+++ b/src/Utopia/Messaging/Adapter.php
@@ -146,7 +146,8 @@ abstract class Adapter
      *     statusCode: int,
      *     response: array<string, mixed>|string|null,
      *     headers: array<string, string>,
-     *     error: string|null
+     *     error: string|null,
+     *     errorCode: int
      * }
      *
      * @throws \Exception If the request fails.
@@ -214,6 +215,7 @@ abstract class Adapter
             'response' => $response,
             'headers' => $responseHeaders,
             'error' => \curl_error($ch),
+            'errorCode' => \curl_errno($ch),
         ];
     }
 
@@ -227,9 +229,10 @@ abstract class Adapter
      *     index: int,
      *     url: string,
      *     statusCode: int,
-     *     response: array<string, mixed>|null,
+     *     response: array<string, mixed>|string|null,
      *     headers: array<string, string>,
-     *     error: string|null
+     *     error: string|null,
+     *     errorCode: int
      * }>
      *
      * @throws Exception
@@ -340,6 +343,7 @@ abstract class Adapter
                 // capture (without copy_handle) if a multi-path adapter needs it.
                 'headers' => [],
                 'error' => \curl_error($ch),
+                'errorCode' => $info['result'],
             ];
 
             \curl_multi_remove_handle($mh, $ch);

--- a/src/Utopia/Messaging/Adapter/Push/FCM.php
+++ b/src/Utopia/Messaging/Adapter/Push/FCM.php
@@ -166,16 +166,40 @@ class FCM extends PushAdapter
                 $response->incrementDeliveredTo();
                 $response->addResult($message->getTo()[$result['index']]);
             } else {
-                $error =
-                    ($result['response']['error']['status'] ?? null) === 'UNREGISTERED'
-                    || ($result['response']['error']['status'] ?? null) === 'NOT_FOUND'
-                        ? $this->getExpiredErrorMessage()
-                        : $result['response']['error']['message'] ?? 'Unknown error';
-
-                $response->addResult($message->getTo()[$result['index']], $error);
+                $response->addResult($message->getTo()[$result['index']], $this->getError($result));
             }
         }
 
         return $response->toArray();
+    }
+
+    /**
+     * @param array{
+     *     statusCode: int,
+     *     response: array<string, mixed>|string|null,
+     *     error: string|null,
+     *     errorCode: int
+     * } $result
+     */
+    protected function getError(array $result): string
+    {
+        $response = \is_array($result['response']) ? $result['response'] : [];
+        $error = \is_array($response['error'] ?? null) ? $response['error'] : [];
+
+        if (\in_array($error['status'] ?? null, ['UNREGISTERED', 'NOT_FOUND'], true)) {
+            return $this->getExpiredErrorMessage();
+        }
+
+        $message = $error['message'] ?? null;
+        if (\is_string($message) && $message !== '') {
+            return $message;
+        }
+
+        $transportError = $result['error'] ?? null;
+        $details = "HTTP status {$result['statusCode']}; cURL error code {$result['errorCode']}";
+
+        return \is_string($transportError) && $transportError !== ''
+            ? "{$transportError} ({$details})"
+            : "Request failed ({$details})";
     }
 }

--- a/tests/Messaging/Adapter/Email/ResendRoutingTest.php
+++ b/tests/Messaging/Adapter/Email/ResendRoutingTest.php
@@ -135,7 +135,7 @@ class ResendStub extends Resend
     /**
      * @param  array<string>  $headers
      * @param  array<string, mixed>|null  $body
-     * @return array{url: string, statusCode: int, response: array<string, mixed>|string|null, headers: array<string, string>, error: string|null}
+     * @return array{url: string, statusCode: int, response: array<string, mixed>|string|null, headers: array<string, string>, error: string|null, errorCode: int}
      */
     protected function request(
         string $method,
@@ -160,6 +160,7 @@ class ResendStub extends Resend
             'response' => $stub['response'],
             'headers' => [],
             'error' => null,
+            'errorCode' => 0,
         ];
     }
 }

--- a/tests/Messaging/Adapter/Email/SESRoutingTest.php
+++ b/tests/Messaging/Adapter/Email/SESRoutingTest.php
@@ -657,7 +657,7 @@ class SESStub extends SES
     /**
      * @param  array<string>  $headers
      * @param  array<string, mixed>|null  $body
-     * @return array{url: string, statusCode: int, response: array<string, mixed>|string|null, headers: array<string, string>, error: string|null}
+     * @return array{url: string, statusCode: int, response: array<string, mixed>|string|null, headers: array<string, string>, error: string|null, errorCode: int}
      */
     protected function request(
         string $method,
@@ -682,6 +682,7 @@ class SESStub extends SES
             'response' => $stub['response'],
             'headers' => $stub['headers'] ?? [],
             'error' => null,
+            'errorCode' => 0,
         ];
     }
 }

--- a/tests/Messaging/Adapter/Push/FCMTest.php
+++ b/tests/Messaging/Adapter/Push/FCMTest.php
@@ -2,6 +2,7 @@
 
 namespace Utopia\Tests\Adapter\Push;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Utopia\Messaging\Adapter\Push\FCM as FCMAdapter;
 
 class FCMTest extends Base
@@ -18,5 +19,59 @@ class FCMTest extends Base
     protected function getTo(): array
     {
         return [\getenv('FCM_TO')];
+    }
+
+    /**
+     * @param array{
+     *     statusCode: int,
+     *     response: array<string, mixed>|string|null,
+     *     error: string|null,
+     *     errorCode: int
+     * } $result
+     */
+    #[DataProvider('errorProvider')]
+    public function testGetError(array $result, string $expected): void
+    {
+        $adapter = new class ('{}') extends FCMAdapter {
+            /**
+             * @param array{
+             *     statusCode: int,
+             *     response: array<string, mixed>|string|null,
+             *     error: string|null,
+             *     errorCode: int
+             * } $result
+             */
+            public function error(array $result): string
+            {
+                return $this->getError($result);
+            }
+        };
+
+        $this->assertSame($expected, $adapter->error($result));
+    }
+
+    /**
+     * @return array<string, array{0: array<string, mixed>, 1: string}>
+     */
+    public static function errorProvider(): array
+    {
+        return [
+            'firebase error message' => [
+                ['statusCode' => 400, 'response' => ['error' => ['message' => 'Invalid registration token']], 'error' => '', 'errorCode' => 0],
+                'Invalid registration token',
+            ],
+            'expired token' => [
+                ['statusCode' => 404, 'response' => ['error' => ['status' => 'NOT_FOUND', 'message' => 'Requested entity was not found.']], 'error' => '', 'errorCode' => 0],
+                'Expired device token',
+            ],
+            'transport error' => [
+                ['statusCode' => 0, 'response' => null, 'error' => 'Connection timed out after 10000 milliseconds', 'errorCode' => 28],
+                'Connection timed out after 10000 milliseconds (HTTP status 0; cURL error code 28)',
+            ],
+            'no error message' => [
+                ['statusCode' => 503, 'response' => 'Service Unavailable', 'error' => '', 'errorCode' => 0],
+                'Request failed (HTTP status 503; cURL error code 0)',
+            ],
+        ];
     }
 }

--- a/tests/Messaging/Adapter/SMS/Msg91Test.php
+++ b/tests/Messaging/Adapter/SMS/Msg91Test.php
@@ -105,7 +105,8 @@ class Msg91TestAdapter extends Msg91
      *     statusCode: int,
      *     response: array<string, mixed>|string|null,
      *     headers: array<string, string>,
-     *     error: string|null
+     *     error: string|null,
+     *     errorCode: int
      * }
      */
     protected function request(
@@ -124,6 +125,7 @@ class Msg91TestAdapter extends Msg91
             'response' => [],
             'headers' => [],
             'error' => null,
+            'errorCode' => 0,
         ];
     }
 }


### PR DESCRIPTION
## What

Improves FCM push delivery error reporting. Previously, when a request failed at the transport layer (timeout, DNS failure, TLS error) or returned a non-JSON body, the per-recipient result was just `"Unknown error"` — with no way to tell *why* delivery failed.

This PR:

1. Adds `errorCode` (cURL errno) to the result shape returned by `Adapter::request()` and `Adapter::requestMulti()`.
2. Extracts FCM error resolution into a `getError()` helper that falls back to transport-level details when Firebase doesn't provide an error message.

## Why

A failed FCM send with `statusCode: 0` and `response: null` (e.g. connection timeout) produced:

```json
{ "recipient": "token123", "error": "Unknown error" }
```

With this change, the same failure produces:

```json
{ "recipient": "token123", "error": "Connection timed out after 10000 milliseconds (HTTP status 0; cURL error code 28)" }
```

This makes production delivery failures actually diagnosable from message logs.

## How

### `Adapter.php` — capture cURL error codes

Single requests use `curl_errno()`, multi requests use the per-handle `result` from `curl_multi_info_read()`:

```php
return [
    'url' => $url,
    'statusCode' => ...,
    'response' => $response,
    'headers' => $responseHeaders,
    'error' => \curl_error($ch),
    'errorCode' => \curl_errno($ch),   // new
];
```

The `requestMulti()` docblock is also corrected: `response` can be `string|null` as well as `array` (it already could at runtime — the annotation was wrong).

### `FCM.php` — layered error resolution

The inline ternary chain in `process()` is replaced with a `getError()` helper that resolves errors in priority order:

```php
protected function getError(array $result): string
{
    $response = \is_array($result['response']) ? $result['response'] : [];
    $error = \is_array($response['error'] ?? null) ? $response['error'] : [];

    // 1. Expired/unregistered token → canonical expired message
    if (\in_array($error['status'] ?? null, ['UNREGISTERED', 'NOT_FOUND'], true)) {
        return $this->getExpiredErrorMessage();
    }

    // 2. Firebase-provided error message
    $message = $error['message'] ?? null;
    if (\is_string($message) && $message !== '') {
        return $message;
    }

    // 3. Transport error + diagnostic codes
    $transportError = $result['error'] ?? null;
    $details = "HTTP status {$result['statusCode']}; cURL error code {$result['errorCode']}";

    return \is_string($transportError) && $transportError !== ''
        ? "{$transportError} ({$details})"
        : "Request failed ({$details})";
}
```

This also hardens against non-array responses (e.g. an HTML error page from a proxy), which previously relied on null coalescing over a string.

## Tests

`FCMTest` gains a data-provider unit test covering all four resolution paths (runs without FCM credentials, unlike the existing integration tests):

| Case | Input | Expected error |
|---|---|---|
| Firebase error message | `response.error.message` set | `Invalid registration token` |
| Expired token | `error.status = NOT_FOUND` | `Expired device token` |
| Transport failure | cURL timeout, errno 28 | `Connection timed out after 10000 milliseconds (HTTP status 0; cURL error code 28)` |
| No message at all | HTTP 503, string body | `Request failed (HTTP status 503; cURL error code 0)` |

Existing test stubs (`ResendRoutingTest`, `SESRoutingTest`, `Msg91Test`) are updated to include `errorCode` in their stubbed result shapes.

```
$ composer test   → OK
$ composer lint   → pass
$ composer analyse → [OK] No errors (phpstan level 6)
```

## Breaking changes

None for consumers of adapters. Subclasses that override `request()`/`requestMulti()` and rely on the documented return shape should add `errorCode` (see updated test stubs for reference).
