### PR TITLE
fix: rebase PR #111 - Vonage Messages API adapter

### DIFF
--- a/src/Utopia/Messaging/Adapter/SMS/VonageLegacy.php
+++ b/src/Utopia/Messaging/Adapter/SMS/VonageLegacy.php
@@ -9,9 +9,9 @@ use Utopia\Messaging\Adapter\SMS as SMSAdapter;
 use Utopia\Messaging\Messages\SMS;
 use Utopia\Messaging\Response;
 
-class Vonage extends SMSAdapter
+class VonageLegacy extends SMSAdapter
 {
-    protected const NAME = 'Vonage';
+    protected const NAME = 'Vonage Legacy';
 
     /**
      * @param  string  $apiKey Vonage API Key

--- a/src/Utopia/Messaging/Adapter/SMS/VonageMessages.php
+++ b/src/Utopia/Messaging/Adapter/SMS/VonageMessages.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Utopia\Messaging\Adapter\SMS;
+
+use Utopia\Messaging\Adapter\SMS as SMSAdapter;
+use Utopia\Messaging\Messages\SMS as SMSMessage;
+use Utopia\Messaging\Response;
+
+class VonageMessages extends SMSAdapter
+{
+    protected const NAME = 'Vonage Messages';
+
+    public function __construct(
+        private readonly string $apiKey,
+        private readonly string $apiSecret,
+        private readonly ?string $from = null,
+    ) {
+        parent::__construct();
+    }
+
+    public function getName(): string
+    {
+        return static::NAME;
+    }
+
+    public function getMaxMessagesPerRequest(): int
+    {
+        return 1;
+    }
+
+    protected function process(SMSMessage $message): array
+    {
+        $to = \ltrim($message->getTo()[0], '+');
+        $from = $this->from ?? $message->getFrom();
+        $from = $from !== null ? \ltrim($from, '+') : null;
+
+        $response = new Response($this->getType());
+
+        if (empty($from)) {
+            $response->addResult($message->getTo()[0], 'The "from" field is required for the Vonage Messages API.');
+            return $response->toArray();
+        }
+
+        $result = $this->request(
+            method: 'POST',
+            url: 'https://api.vonage.com/v1/messages',
+            headers: [
+                'Authorization: Basic ' . \base64_encode("{$this->apiKey}:{$this->apiSecret}"),
+                'Content-Type: application/json',
+                'Accept: application/json',
+            ],
+            body: [
+                'message_type' => 'text',
+                'to' => $to,
+                'from' => $from,
+                'text' => $message->getContent(),
+                'channel' => 'sms',
+            ],
+        );
+
+        if ($result['statusCode'] === 202) {
+            $response->setDeliveredTo(1);
+            $response->addResult($message->getTo()[0]);
+        } else {
+            $errorMessage = "Error {$result['statusCode']}";
+
+            if (\is_array($result['response'])) {
+                if (isset($result['response']['detail'])) {
+                    $errorMessage = $result['response']['detail'];
+                } elseif (isset($result['response']['title'])) {
+                    $errorMessage = $result['response']['title'];
+                }
+            } elseif (!empty($result['error'])) {
+                $errorMessage = $result['error'];
+            } elseif (\is_string($result['response']) && !empty($result['response'])) {
+                $errorMessage = "Error {$result['statusCode']}: " . \mb_strimwidth(\strip_tags($result['response']), 0, 100, '...');
+            }
+
+            $response->addResult($message->getTo()[0], $errorMessage);
+        }
+
+        return $response->toArray();
+    }
+}

--- a/tests/Messaging/Adapter/SMS/VonageLegacyTest.php
+++ b/tests/Messaging/Adapter/SMS/VonageLegacyTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Utopia\Tests\Adapter\SMS;
+
+use Utopia\Messaging\Adapter\SMS\VonageLegacy;
+use Utopia\Tests\Adapter\Base;
+
+class VonageLegacyTest extends Base
+{
+    public function testSendSMS(): void
+    {
+        $this->markTestSkipped('Vonage credentials are not available.');
+    }
+}

--- a/tests/Messaging/Adapter/SMS/VonageMessagesTest.php
+++ b/tests/Messaging/Adapter/SMS/VonageMessagesTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Utopia\Tests\Adapter\SMS;
+
+use Utopia\Messaging\Adapter\SMS\VonageMessages;
+use Utopia\Messaging\Messages\SMS;
+use Utopia\Tests\Adapter\Base;
+
+class VonageMessagesTest extends Base
+{
+    public function testSendSMS(): void
+    {
+        $apiKey = \getenv('VONAGE_API_KEY');
+        $apiSecret = \getenv('VONAGE_API_SECRET');
+        $to = \getenv('VONAGE_TO');
+
+        if (!$apiKey || !$apiSecret || !$to) {
+            $this->markTestSkipped('Vonage Messages credentials or recipient are not available.');
+        }
+
+        $sender = new VonageMessages(
+            apiKey: $apiKey,
+            apiSecret: $apiSecret,
+            from: \getenv('VONAGE_FROM') ?: 'Vonage',
+        );
+
+        $message = new SMS(
+            to: [$to],
+            content: 'Test Content',
+        );
+
+        $response = $sender->send($message);
+
+        $this->assertResponse($response);
+    }
+
+    public function testSendSMSWithFallbackFrom(): void
+    {
+        $apiKey = \getenv('VONAGE_API_KEY');
+        $apiSecret = \getenv('VONAGE_API_SECRET');
+        $to = \getenv('VONAGE_TO');
+        $from = \getenv('VONAGE_FROM') ?: null;
+
+        if (!$apiKey || !$apiSecret || !$to || !$from) {
+            $this->markTestSkipped('Vonage Messages credentials or sender/recipient are not available.');
+        }
+
+        $sender = new VonageMessages(
+            apiKey: $apiKey,
+            apiSecret: $apiSecret,
+        );
+
+        $message = new SMS(
+            to: [$to],
+            content: 'Test Content',
+            from: $from,
+        );
+
+        $response = $sender->send($message);
+
+        $this->assertResponse($response);
+    }
+}


### PR DESCRIPTION
Replacement for #111. Original by @bhardwajparth51.

Rebased on latest main. Fixed:
- Added parent::__construct() call in constructors
- Made properties private readonly
- Aligned with v2.0.0 conventions