### PR TITLE
fix: rebase PR #99 - SMSGateApp SMS adapter

### DIFF
--- a/src/Utopia/Messaging/Adapter/SMS/SMSGateApp.php
+++ b/src/Utopia/Messaging/Adapter/SMS/SMSGateApp.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Utopia\Messaging\Adapter\SMS;
+
+use Utopia\Messaging\Adapter\SMS as SMSAdapter;
+use Utopia\Messaging\Messages\SMS as SMSMessage;
+use Utopia\Messaging\Response;
+
+class SMSGateApp extends SMSAdapter
+{
+    protected const NAME = 'SMS Gateway for Android™';
+    protected const DEFAULT_API_ENDPOINT = 'https://api.sms-gate.app/3rdparty/v1';
+
+    public function __construct(
+        private readonly string $apiUsername,
+        private readonly string $apiPassword,
+        private readonly string $apiEndpoint = self::DEFAULT_API_ENDPOINT,
+    ) {
+        parent::__construct();
+    }
+
+    public function getName(): string
+    {
+        return static::NAME;
+    }
+
+    public function getMaxMessagesPerRequest(): int
+    {
+        return 10;
+    }
+
+    protected function process(SMSMessage $message): array
+    {
+        $response = new Response($this->getType());
+
+        $body = [
+            'textMessage' => [
+                'text' => $message->getContent(),
+            ],
+            'phoneNumbers' => $message->getTo(),
+        ];
+
+        $result = $this->request(
+            method: 'POST',
+            url: $this->apiEndpoint . '/messages?skipPhoneValidation=true',
+            headers: [
+                'Content-Type: application/json',
+                'Authorization: Basic ' . base64_encode("{$this->apiUsername}:{$this->apiPassword}"),
+            ],
+            body: $body,
+        );
+
+        if ($result['statusCode'] === 202) {
+            $success = 0;
+            foreach ($result['response']['recipients'] as $recipient) {
+                $response->addResult($recipient['phoneNumber'], $recipient['error'] ?? '');
+
+                if ($recipient['state'] !== 'Failed') {
+                    $success++;
+                }
+            }
+
+            $response->setDeliveredTo($success);
+        } else {
+            $errorMessage = $result['response']['message'] ?? 'Unknown error';
+            foreach ($message->getTo() as $recipient) {
+                $response->addResult($recipient, $errorMessage);
+            }
+        }
+
+        return $response->toArray();
+    }
+}

--- a/tests/Messaging/Adapter/SMS/SMSGateAppTest.php
+++ b/tests/Messaging/Adapter/SMS/SMSGateAppTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Utopia\Tests\Adapter\SMS;
+
+use Utopia\Messaging\Adapter\SMS\SMSGateApp;
+use Utopia\Messaging\Messages\SMS;
+use Utopia\Tests\Adapter\Base;
+
+class SMSGateAppTest extends Base
+{
+    public function testSendSMS(): void
+    {
+        $username = \getenv('SMSGATEAPP_USERNAME');
+        $password = \getenv('SMSGATEAPP_PASSWORD');
+        $to = \getenv('SMSGATEAPP_TO');
+
+        if (!$username || !$password || !$to) {
+            $this->markTestSkipped('SMSGateApp credentials not configured');
+        }
+
+        $endpoint = \getenv('SMSGATEAPP_ENDPOINT') ?: null;
+
+        $sender = new SMSGateApp($username, $password, $endpoint);
+
+        $message = new SMS(
+            to: [$to],
+            content: 'Test content from SMSGateApp'
+        );
+
+        $response = $sender->send($message);
+
+        $this->assertResponse($response);
+    }
+}


### PR DESCRIPTION
Replacement for #99. Original by @capcom6.

Rebased on latest main. Fixed:
- Added parent::__construct() call
- Made properties private readonly
- Moved apiEndpoint default to constructor parameter default
- Aligned with v2.0.0 conventions