### PR TITLE
fix: rebase PR #84 - SmsGatewayHub SMS adapter

### DIFF
--- a/src/Utopia/Messaging/Adapter/SMS/SmsGatewayHub.php
+++ b/src/Utopia/Messaging/Adapter/SMS/SmsGatewayHub.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Utopia\Messaging\Adapter\SMS;
+
+use Utopia\Messaging\Adapter\SMS as SMSAdapter;
+use Utopia\Messaging\Messages\SMS as SMSMessage;
+use Utopia\Messaging\Response;
+
+class SmsGatewayHub extends SMSAdapter
+{
+    protected const NAME = 'SMSGatewayHub';
+
+    public function __construct(
+        private readonly string $apiKey,
+        private readonly string $senderId,
+        private readonly string $route,
+        private readonly string $dltTemplateId,
+        private readonly string $peId,
+    ) {
+        parent::__construct();
+    }
+
+    public function getName(): string
+    {
+        return static::NAME;
+    }
+
+    public function getMaxMessagesPerRequest(): int
+    {
+        return 100;
+    }
+
+    protected function process(SMSMessage $message): array
+    {
+        $recipients = [];
+        foreach ($message->getTo() as $recipient) {
+            $recipients[] = \ltrim($recipient, '+');
+        }
+
+        $response = new Response($this->getType());
+
+        $queryParams = \http_build_query([
+            'apiKey' => $this->apiKey,
+            'senderid' => $this->senderId,
+            'channel' => 'Trans',
+            'DCS' => '0',
+            'flashsms' => '0',
+            'number' => \implode(',', $recipients),
+            'text' => $message->getContent(),
+            'route' => $this->route,
+            'DLTTemplateId' => $this->dltTemplateId,
+            'PEID' => $this->peId,
+        ]);
+
+        $url = 'https://login.smsgatewayhub.com/api/mt/SendSMS?' . $queryParams;
+        $result = $this->request(
+            'GET',
+            $url,
+            [
+                'Content-Type: application/json',
+            ]
+        );
+
+        if ($result['statusCode'] === 200) {
+            $response->setDeliveredTo(\count($message->getTo()));
+            foreach ($message->getTo() as $to) {
+                $response->addResult($to);
+            }
+        } else {
+            foreach ($message->getTo() as $to) {
+                $response->addResult($to, 'Unknown error');
+            }
+        }
+
+        return $response->toArray();
+    }
+}

--- a/tests/Messaging/Adapter/SMS/SmsGatewayHubTest.php
+++ b/tests/Messaging/Adapter/SMS/SmsGatewayHubTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Utopia\Tests\Adapter\SMS;
+
+use Utopia\Messaging\Adapter\SMS\SmsGatewayHub;
+use Utopia\Messaging\Messages\SMS;
+use Utopia\Tests\Adapter\Base;
+
+class SmsGatewayHubTest extends Base
+{
+    public function testSendSMS(): void
+    {
+        $apiKey = \getenv('SMS_GATEWAY_APIKEY');
+        $senderId = \getenv('SMS_GATEWAY_SENDER_ID');
+        $route = \getenv('SMS_GATEWAY_ROUTE');
+        $dltTemplateId = \getenv('SMS_GATEWAY_DLT_TEMPLATE_ID');
+        $peId = \getenv('SMS_GATEWAY_PEID');
+        $to = \getenv('SMS_GATEWAY_TO');
+
+        if (!$apiKey || !$senderId || !$route || !$dltTemplateId || !$peId || !$to) {
+            $this->markTestSkipped('SMSGatewayHub credentials not configured');
+        }
+
+        $sender = new SmsGatewayHub(
+            apiKey: $apiKey,
+            senderId: $senderId,
+            route: $route,
+            dltTemplateId: $dltTemplateId,
+            peId: $peId,
+        );
+
+        $message = new SMS(
+            to: [$to],
+            content: 'Your login OTP is 789456.',
+        );
+
+        $response = $sender->send($message);
+
+        $this->assertResponse($response);
+    }
+}


### PR DESCRIPTION
Replacement for #84. Original by @kevinjosephjohn.

Rebased on latest main. Fixed:
- Added parent::__construct() call
- Made properties private readonly
- Removed error_log debugging calls
- Fixed test to use env vars with skippable check
- Aligned with v2.0.0 conventions